### PR TITLE
fix(clustering): wire config radius, fix marker bugs

### DIFF
--- a/Source/ResourceNodeMarker/Private/RNM_ClusterManager.cpp
+++ b/Source/ResourceNodeMarker/Private/RNM_ClusterManager.cpp
@@ -499,16 +499,10 @@ void URNM_ClusterManager::OnNodeDiscovered(UWorld* World, int32 NodeIndex)
 
         for (const int32 SourceIndex : ClusterIndices)
         {
-            if (SourceIndex != TargetClusterIndex
-                && !MergeClusters(World, TargetClusterIndex, SourceIndex, /*bRemoveSourceMarker=*/false))
-            {
-                DiscoveredClusters = ClustersBeforeMerge;
-                NodeToClusterMap = NodeToClusterBeforeMerge;
-                UE_LOG(LogResourceNodeMarker, Warning,
-                    TEXT("RNM_ClusterManager: Cluster merge aborted for %s"),
-                    *NewNode.ResourceName.ToString());
-                return;
-            }
+            if (SourceIndex == TargetClusterIndex) continue;
+            check(DiscoveredClusters.IsValidIndex(TargetClusterIndex));
+            check(DiscoveredClusters.IsValidIndex(SourceIndex));
+            MergeClusters(World, TargetClusterIndex, SourceIndex, /*bRemoveSourceMarker=*/false);
         }
 
         DiscoveredClusters[TargetClusterIndex].RecalculateCenter();
@@ -519,19 +513,53 @@ void URNM_ClusterManager::OnNodeDiscovered(UWorld* World, int32 NodeIndex)
             World, DiscoveredClusters[TargetClusterIndex], ResourceVisuals, Config, NewGUID))
         {
             DiscoveredClusters[TargetClusterIndex].CurrentMarkerGUID = NewGUID;
-            DiscoveredNodeIndices.Add(NodeIndex);
 
+            bool bAllSourceMarkersRemoved = true;
             for (const int32 SourceIndex : ClusterIndices)
             {
-                if (SourceIndex != TargetClusterIndex)
-                    TryRemoveClusterMapMarker(World, DiscoveredClusters[SourceIndex]);
+                if (SourceIndex != TargetClusterIndex
+                    && !TryRemoveClusterMapMarker(World, DiscoveredClusters[SourceIndex]))
+                {
+                    bAllSourceMarkersRemoved = false;
+                    break;
+                }
             }
 
-            UE_LOG(LogResourceNodeMarker, Log,
-                TEXT("RNM_ClusterManager: Merged %d clusters for %s (%d nodes)"),
-                ClusterIndices.Num(),
-                *NewNode.ResourceName.ToString(),
-                DiscoveredClusters[TargetClusterIndex].Nodes.Num());
+            if (bAllSourceMarkersRemoved)
+            {
+                DiscoveredNodeIndices.Add(NodeIndex);
+
+                UE_LOG(LogResourceNodeMarker, Log,
+                    TEXT("RNM_ClusterManager: Merged %d clusters for %s (%d nodes)"),
+                    ClusterIndices.Num(),
+                    *NewNode.ResourceName.ToString(),
+                    DiscoveredClusters[TargetClusterIndex].Nodes.Num());
+            }
+            else
+            {
+                if (AFGMapManager* MapManager = AFGMapManager::Get(World))
+                    MapManager->Authority_RemoveMapMarkerByID(NewGUID);
+
+                DiscoveredClusters = ClustersBeforeMerge;
+                NodeToClusterMap = NodeToClusterBeforeMerge;
+
+                for (const int32 Idx : ClusterIndices)
+                {
+                    FResourceNodeCluster& C = DiscoveredClusters[Idx];
+                    if (C.Nodes.Num() == 0) continue;
+
+                    FGuid RestoredGUID;
+                    if (RNM_MapMarkerService::CreateOrUpdateClusterMarker(
+                        World, C, ResourceVisuals, Config, RestoredGUID))
+                    {
+                        C.CurrentMarkerGUID = RestoredGUID;
+                    }
+                }
+
+                UE_LOG(LogResourceNodeMarker, Warning,
+                    TEXT("RNM_ClusterManager: Cluster merge rolled back — failed to remove source marker for %s"),
+                    *NewNode.ResourceName.ToString());
+            }
         }
         else
         {
@@ -582,52 +610,67 @@ void URNM_ClusterManager::OnExtractorPlaced(UWorld* World, const FVector& NodeLo
 
     int32 ClusterIndex = *ClusterIdxPtr;
     FResourceNodeCluster& Cluster = DiscoveredClusters[ClusterIndex];
+    const FResourceNodeCluster ClusterBefore = Cluster;
 
-    // Delete existing cluster marker
-    if (Cluster.CurrentMarkerGUID.IsValid())
+    const auto NodeMatchesLocation = [&](const FResourceNodeInfo& Node)
     {
-        AFGMapManager* MapManager = AFGMapManager::Get(World);
-        if (MapManager)
-        {
-            MapManager->Authority_RemoveMapMarkerByID(Cluster.CurrentMarkerGUID);
-            Cluster.CurrentMarkerGUID.Invalidate();
+        return FVector::DistSquared(Node.Location, NodeLocation)
+            <= RNM_MapMarkerService::MARKER_LOCATION_TOLERANCE_SQ;
+    };
 
-            UE_LOG(LogResourceNodeMarker, Log,
-                TEXT("RNM_ClusterManager: Removed cluster marker for %s due to extractor placement"),
-                *Cluster.ResourceName.ToString());
+    bool bRemovedNode = false;
+    for (const FResourceNodeInfo& Node : Cluster.Nodes)
+    {
+        if (NodeMatchesLocation(Node))
+        {
+            bRemovedNode = true;
+            break;
         }
     }
+    if (!bRemovedNode) return;
 
-    // Remove the tapped node from the cluster
-    Cluster.Nodes.RemoveAll([&](const FResourceNodeInfo& Node)
-        {
-            return FVector::DistSquared(Node.Location, NodeLocation) <= RNM_MapMarkerService::MARKER_LOCATION_TOLERANCE_SQ;
-        });
-
+    Cluster.Nodes.RemoveAll(NodeMatchesLocation);
     NodeToClusterMap.Remove(FoundNodeIndex);
 
-    // If cluster still has nodes recreate marker
-    if (Cluster.Nodes.Num() > 0)
+    if (Cluster.Nodes.Num() == 0)
     {
-        Cluster.RecalculateCenter();
-        Cluster.RecalculateDominantPurity();
-
-        FGuid NewGUID;
-        if (RNM_MapMarkerService::CreateOrUpdateClusterMarker(
-            World, Cluster, ResourceVisuals, Config, NewGUID))
+        if (TryRemoveClusterMapMarker(World, Cluster))
         {
-            Cluster.CurrentMarkerGUID = NewGUID;
-
             UE_LOG(LogResourceNodeMarker, Log,
-                TEXT("RNM_ClusterManager: Recreated cluster marker for %s (%d nodes remaining)"),
-                *Cluster.ResourceName.ToString(),
-                Cluster.Nodes.Num());
+                TEXT("RNM_ClusterManager: Cluster for %s is now empty, marker deleted"),
+                *Cluster.ResourceName.ToString());
         }
+        else
+        {
+            Cluster = ClusterBefore;
+            NodeToClusterMap.Add(FoundNodeIndex, ClusterIndex);
+            UE_LOG(LogResourceNodeMarker, Warning,
+                TEXT("RNM_ClusterManager: Failed to remove marker for empty cluster %s — node kept in cluster"),
+                *Cluster.ResourceName.ToString());
+        }
+        return;
+    }
+
+    Cluster.RecalculateCenter();
+    Cluster.RecalculateDominantPurity();
+
+    FGuid NewGUID;
+    if (RNM_MapMarkerService::CreateOrUpdateClusterMarker(
+        World, Cluster, ResourceVisuals, Config, NewGUID))
+    {
+        Cluster.CurrentMarkerGUID = NewGUID;
+
+        UE_LOG(LogResourceNodeMarker, Log,
+            TEXT("RNM_ClusterManager: Recreated cluster marker for %s (%d nodes remaining)"),
+            *Cluster.ResourceName.ToString(),
+            Cluster.Nodes.Num());
     }
     else
     {
-        UE_LOG(LogResourceNodeMarker, Log,
-            TEXT("RNM_ClusterManager: Cluster for %s is now empty, marker deleted"),
+        Cluster = ClusterBefore;
+        NodeToClusterMap.Add(FoundNodeIndex, ClusterIndex);
+        UE_LOG(LogResourceNodeMarker, Warning,
+            TEXT("RNM_ClusterManager: Failed to recreate cluster marker for %s — node kept in cluster"),
             *Cluster.ResourceName.ToString());
     }
 }

--- a/Source/ResourceNodeMarker/Private/RNM_ClusterManager.cpp
+++ b/Source/ResourceNodeMarker/Private/RNM_ClusterManager.cpp
@@ -12,21 +12,41 @@ int32 PickMergeTargetClusterIndex(
     const TArray<FResourceNodeCluster>& Clusters,
     const TArray<int32>& CandidateIndices)
 {
-    int32 BestIndex = CandidateIndices[0];
-    int32 BestScore = TNumericLimits<int32>::Min();
+    check(CandidateIndices.Num() > 0);
 
-    for (const int32 Idx : CandidateIndices)
+    int32 BestIndex = CandidateIndices[0];
+    const FResourceNodeCluster* BestCluster = Clusters.IsValidIndex(BestIndex)
+        ? &Clusters[BestIndex] : nullptr;
+
+    for (int32 i = 1; i < CandidateIndices.Num(); ++i)
     {
+        const int32 Idx = CandidateIndices[i];
         if (!Clusters.IsValidIndex(Idx)) continue;
 
-        int32 Score = Clusters[Idx].Nodes.Num();
-        if (Clusters[Idx].CurrentMarkerGUID.IsValid())
-            Score += 10000;
-
-        if (Score > BestScore)
+        const FResourceNodeCluster& Candidate = Clusters[Idx];
+        if (!BestCluster)
         {
-            BestScore = Score;
             BestIndex = Idx;
+            BestCluster = &Candidate;
+            continue;
+        }
+
+        const bool bCandidateHasMarker = Candidate.CurrentMarkerGUID.IsValid();
+        const bool bBestHasMarker = BestCluster->CurrentMarkerGUID.IsValid();
+        if (bCandidateHasMarker != bBestHasMarker)
+        {
+            if (bCandidateHasMarker)
+            {
+                BestIndex = Idx;
+                BestCluster = &Candidate;
+            }
+            continue;
+        }
+
+        if (Candidate.Nodes.Num() > BestCluster->Nodes.Num())
+        {
+            BestIndex = Idx;
+            BestCluster = &Candidate;
         }
     }
 
@@ -297,20 +317,47 @@ void URNM_ClusterManager::ApplySoloClusteringLayoutIfNeeded()
     NodeToClusterMap = MoveTemp(NewNodeToCluster);
 }
 
-void URNM_ClusterManager::MergeClusters(UWorld* World, int32 TargetIndex, int32 SourceIndex)
+bool URNM_ClusterManager::TryRemoveClusterMapMarker(UWorld* World, FResourceNodeCluster& Cluster)
 {
+    if (!Cluster.CurrentMarkerGUID.IsValid()) return true;
+
+    if (!World)
+    {
+        UE_LOG(LogResourceNodeMarker, Warning,
+            TEXT("RNM_ClusterManager: Cannot remove cluster marker for %s without a valid world"),
+            *Cluster.ResourceName.ToString());
+        return false;
+    }
+
+    AFGMapManager* MapManager = AFGMapManager::Get(World);
+    if (!MapManager)
+    {
+        UE_LOG(LogResourceNodeMarker, Warning,
+            TEXT("RNM_ClusterManager: Cannot remove cluster marker for %s — AFGMapManager unavailable"),
+            *Cluster.ResourceName.ToString());
+        return false;
+    }
+
+    MapManager->Authority_RemoveMapMarkerByID(Cluster.CurrentMarkerGUID);
+    Cluster.CurrentMarkerGUID.Invalidate();
+    UE_LOG(LogResourceNodeMarker, Log,
+        TEXT("RNM_ClusterManager: Removed cluster marker for %s"),
+        *Cluster.ResourceName.ToString());
+    return true;
+}
+
+bool URNM_ClusterManager::MergeClusters(
+    UWorld* World, int32 TargetIndex, int32 SourceIndex, bool bRemoveSourceMarker)
+{
+    if (!DiscoveredClusters.IsValidIndex(TargetIndex) || !DiscoveredClusters.IsValidIndex(SourceIndex))
+        return false;
+
     FResourceNodeCluster& SourceCluster = DiscoveredClusters[SourceIndex];
 
-    if (SourceCluster.CurrentMarkerGUID.IsValid() && World)
+    if (bRemoveSourceMarker && SourceCluster.CurrentMarkerGUID.IsValid())
     {
-        if (AFGMapManager* MapManager = AFGMapManager::Get(World))
-        {
-            MapManager->Authority_RemoveMapMarkerByID(SourceCluster.CurrentMarkerGUID);
-            SourceCluster.CurrentMarkerGUID.Invalidate();
-            UE_LOG(LogResourceNodeMarker, Log,
-                TEXT("RNM_ClusterManager: Removed merged-away cluster marker for %s"),
-                *SourceCluster.ResourceName.ToString());
-        }
+        if (!TryRemoveClusterMapMarker(World, SourceCluster))
+            return false;
     }
 
     // Remap all nodes from source to target
@@ -323,6 +370,7 @@ void URNM_ClusterManager::MergeClusters(UWorld* World, int32 TargetIndex, int32 
     DiscoveredClusters[TargetIndex].MergeWith(SourceCluster);
 
     SourceCluster.Nodes.Reset();
+    return true;
 }
 
 void URNM_ClusterManager::OnNodeDiscovered(UWorld* World, int32 NodeIndex)
@@ -438,6 +486,11 @@ void URNM_ClusterManager::OnNodeDiscovered(UWorld* World, int32 NodeIndex)
     }
     else
     {
+        check(NeighborClusterIndices.Num() > 1);
+
+        const TArray<FResourceNodeCluster> ClustersBeforeMerge = DiscoveredClusters;
+        const TMap<int32, int32> NodeToClusterBeforeMerge = NodeToClusterMap;
+
         TArray<int32> ClusterIndices = NeighborClusterIndices.Array();
         const int32 TargetClusterIndex = PickMergeTargetClusterIndex(DiscoveredClusters, ClusterIndices);
 
@@ -446,8 +499,16 @@ void URNM_ClusterManager::OnNodeDiscovered(UWorld* World, int32 NodeIndex)
 
         for (const int32 SourceIndex : ClusterIndices)
         {
-            if (SourceIndex != TargetClusterIndex)
-                MergeClusters(World, TargetClusterIndex, SourceIndex);
+            if (SourceIndex != TargetClusterIndex
+                && !MergeClusters(World, TargetClusterIndex, SourceIndex, /*bRemoveSourceMarker=*/false))
+            {
+                DiscoveredClusters = ClustersBeforeMerge;
+                NodeToClusterMap = NodeToClusterBeforeMerge;
+                UE_LOG(LogResourceNodeMarker, Warning,
+                    TEXT("RNM_ClusterManager: Cluster merge aborted for %s"),
+                    *NewNode.ResourceName.ToString());
+                return;
+            }
         }
 
         DiscoveredClusters[TargetClusterIndex].RecalculateCenter();
@@ -460,6 +521,12 @@ void URNM_ClusterManager::OnNodeDiscovered(UWorld* World, int32 NodeIndex)
             DiscoveredClusters[TargetClusterIndex].CurrentMarkerGUID = NewGUID;
             DiscoveredNodeIndices.Add(NodeIndex);
 
+            for (const int32 SourceIndex : ClusterIndices)
+            {
+                if (SourceIndex != TargetClusterIndex)
+                    TryRemoveClusterMapMarker(World, DiscoveredClusters[SourceIndex]);
+            }
+
             UE_LOG(LogResourceNodeMarker, Log,
                 TEXT("RNM_ClusterManager: Merged %d clusters for %s (%d nodes)"),
                 ClusterIndices.Num(),
@@ -468,10 +535,11 @@ void URNM_ClusterManager::OnNodeDiscovered(UWorld* World, int32 NodeIndex)
         }
         else
         {
+            DiscoveredClusters = ClustersBeforeMerge;
+            NodeToClusterMap = NodeToClusterBeforeMerge;
             UE_LOG(LogResourceNodeMarker, Warning,
-                TEXT("RNM_ClusterManager: Merge succeeded but marker create failed for %s"),
+                TEXT("RNM_ClusterManager: Cluster merge rolled back — marker create failed for %s"),
                 *NewNode.ResourceName.ToString());
-            DiscoveredNodeIndices.Add(NodeIndex);
         }
     }
 }

--- a/Source/ResourceNodeMarker/Private/RNM_ClusterManager.cpp
+++ b/Source/ResourceNodeMarker/Private/RNM_ClusterManager.cpp
@@ -16,8 +16,10 @@ void URNM_ClusterManager::Initialize(
     SpatialGrid = &InSpatialGrid;
     ResourceVisuals = InResourceVisuals;
     Config = InConfig;
-    ClusterRadiusSq = (InConfig.ClusterRadius * 100.0f) * (InConfig.ClusterRadius * 100.0f);
-    ClusterHeightTolerance = InConfig.ClusterHeightTolerance * 100.0f;
+    const float ClusterRadiusCm = FResourceNodeMarker_ConfigStruct::GetClusterRadiusCm(InConfig);
+    ClusterRadiusSq = ClusterRadiusCm * ClusterRadiusCm;
+    ClusterHeightTolerance = FResourceNodeMarker_ConfigStruct::GetClusterHeightToleranceCm(InConfig);
+    GridCellSizeCm = ClusterRadiusCm;
 
     DiscoveredClusters.Reset();
     NodeToClusterMap.Reset();
@@ -45,7 +47,7 @@ void URNM_ClusterManager::RebuildClustersFromExistingMarkers(UWorld* World)
         if (!bHasStableId)
             bHasStableId = RNM_MapMarkerService::TryParseClassIdFromMarkerName(Marker.Name, StableClassId);
 
-        FIntVector Cell = RNM_NodeScanner::GetGridCell(Marker.Location);
+        FIntVector Cell = RNM_NodeScanner::GetGridCell(Marker.Location, GridCellSizeCm);
         TArray<int32> CandidateIndices = RNM_NodeScanner::GetNeighborCellIndices(*SpatialGrid, Cell);
 
         FString NameForLegacy = Marker.Name;
@@ -64,7 +66,8 @@ void URNM_ClusterManager::RebuildClustersFromExistingMarkers(UWorld* World)
             if (DiscoveredNodeIndices.Contains(NodeIndex)) continue;
 
             const FResourceNodeInfo& Node = (*ResourceNodes)[NodeIndex];
-            if (FVector::DistSquared(Node.Location, Marker.Location) > RNM_NodeScanner::CLUSTER_RADIUS_SQ) continue;
+            if (FVector::DistSquared(Node.Location, Marker.Location) > ClusterRadiusSq) continue;
+            if (FMath::Abs(Node.Location.Z - Marker.Location.Z) > ClusterHeightTolerance) continue;
 
             if (bHasStableId)
             {
@@ -92,7 +95,8 @@ void URNM_ClusterManager::RebuildClustersFromExistingMarkers(UWorld* World)
             {
                 if (DiscoveredNodeIndices.Contains(NodeIndex)) continue;
                 const FResourceNodeInfo& Node = (*ResourceNodes)[NodeIndex];
-                if (FVector::DistSquared(Node.Location, Marker.Location) > RNM_NodeScanner::CLUSTER_RADIUS_SQ) continue;
+                if (FVector::DistSquared(Node.Location, Marker.Location) > ClusterRadiusSq) continue;
+                if (FMath::Abs(Node.Location.Z - Marker.Location.Z) > ClusterHeightTolerance) continue;
                 ClassIdsInRange.Add(Node.ResourceName);
             }
             if (ClassIdsInRange.Num() == 1)
@@ -101,7 +105,8 @@ void URNM_ClusterManager::RebuildClustersFromExistingMarkers(UWorld* World)
                 {
                     if (DiscoveredNodeIndices.Contains(NodeIndex)) continue;
                     const FResourceNodeInfo& Node = (*ResourceNodes)[NodeIndex];
-                    if (FVector::DistSquared(Node.Location, Marker.Location) > RNM_NodeScanner::CLUSTER_RADIUS_SQ) continue;
+                    if (FVector::DistSquared(Node.Location, Marker.Location) > ClusterRadiusSq) continue;
+                    if (FMath::Abs(Node.Location.Z - Marker.Location.Z) > ClusterHeightTolerance) continue;
                     ClusterNodeIndices.AddUnique(NodeIndex);
                 }
             }
@@ -220,7 +225,7 @@ int32 URNM_ClusterManager::FindResourceNodeIndex(const FResourceNodeInfo& Info) 
 
 void URNM_ClusterManager::ApplySoloClusteringLayoutIfNeeded()
 {
-    if (Config.bClusterNodes) return;
+    if (FResourceNodeMarker_ConfigStruct::IsClusteringEnabled(Config)) return;
 
     TArray<FResourceNodeCluster> Split;
     TMap<int32, int32> NewNodeToCluster;
@@ -264,8 +269,22 @@ void URNM_ClusterManager::ApplySoloClusteringLayoutIfNeeded()
     NodeToClusterMap = MoveTemp(NewNodeToCluster);
 }
 
-void URNM_ClusterManager::MergeClusters(int32 TargetIndex, int32 SourceIndex)
+void URNM_ClusterManager::MergeClusters(UWorld* World, int32 TargetIndex, int32 SourceIndex)
 {
+    FResourceNodeCluster& SourceCluster = DiscoveredClusters[SourceIndex];
+
+    if (SourceCluster.CurrentMarkerGUID.IsValid() && World)
+    {
+        if (AFGMapManager* MapManager = AFGMapManager::Get(World))
+        {
+            MapManager->Authority_RemoveMapMarkerByID(SourceCluster.CurrentMarkerGUID);
+            UE_LOG(LogResourceNodeMarker, Log,
+                TEXT("RNM_ClusterManager: Removed merged-away cluster marker for %s"),
+                *SourceCluster.ResourceName.ToString());
+        }
+        SourceCluster.CurrentMarkerGUID.Invalidate();
+    }
+
     // Remap all nodes from source to target
     for (auto& Pair : NodeToClusterMap)
     {
@@ -273,11 +292,9 @@ void URNM_ClusterManager::MergeClusters(int32 TargetIndex, int32 SourceIndex)
             Pair.Value = TargetIndex;
     }
 
-    DiscoveredClusters[TargetIndex].MergeWith(DiscoveredClusters[SourceIndex]);
+    DiscoveredClusters[TargetIndex].MergeWith(SourceCluster);
 
-    // Invalidate source
-    DiscoveredClusters[SourceIndex].Nodes.Reset();
-    DiscoveredClusters[SourceIndex].CurrentMarkerGUID.Invalidate();
+    SourceCluster.Nodes.Reset();
 }
 
 void URNM_ClusterManager::OnNodeDiscovered(UWorld* World, int32 NodeIndex)
@@ -288,7 +305,7 @@ void URNM_ClusterManager::OnNodeDiscovered(UWorld* World, int32 NodeIndex)
 
     DiscoveredNodeIndices.Add(NodeIndex);
 
-    if (!Config.bClusterNodes)
+    if (!FResourceNodeMarker_ConfigStruct::IsClusteringEnabled(Config))
     {
         FResourceNodeCluster NewCluster;
         NewCluster.ResourceName = NewNode.ResourceName;
@@ -312,7 +329,7 @@ void URNM_ClusterManager::OnNodeDiscovered(UWorld* World, int32 NodeIndex)
         return;
     }
 
-    FIntVector Cell = RNM_NodeScanner::GetGridCell(NewNode.Location);
+    FIntVector Cell = RNM_NodeScanner::GetGridCell(NewNode.Location, GridCellSizeCm);
     TArray<int32> CandidateIndices = RNM_NodeScanner::GetNeighborCellIndices(*SpatialGrid, Cell);
 
     TSet<int32> NeighborClusterIndices;
@@ -324,7 +341,7 @@ void URNM_ClusterManager::OnNodeDiscovered(UWorld* World, int32 NodeIndex)
         const FResourceNodeInfo& Candidate = (*ResourceNodes)[CandidateIndex];
 
         if (Candidate.ResourceName != NewNode.ResourceName) continue;
-        if (FVector::DistSquared(NewNode.Location, Candidate.Location) > RNM_NodeScanner::CLUSTER_RADIUS_SQ) continue;
+        if (FVector::DistSquared(NewNode.Location, Candidate.Location) > ClusterRadiusSq) continue;
         if (FMath::Abs(NewNode.Location.Z - Candidate.Location.Z) > ClusterHeightTolerance) continue;
 
         if (const int32* ClusterIdx = NodeToClusterMap.Find(CandidateIndex))
@@ -382,7 +399,7 @@ void URNM_ClusterManager::OnNodeDiscovered(UWorld* World, int32 NodeIndex)
         NodeToClusterMap.Add(NodeIndex, TargetClusterIndex);
 
         for (int32 i = 1; i < ClusterIndices.Num(); i++)
-            MergeClusters(TargetClusterIndex, ClusterIndices[i]);
+            MergeClusters(World, TargetClusterIndex, ClusterIndices[i]);
 
         DiscoveredClusters[TargetClusterIndex].RecalculateCenter();
         DiscoveredClusters[TargetClusterIndex].RecalculateDominantPurity();
@@ -466,6 +483,8 @@ void URNM_ClusterManager::OnExtractorPlaced(UWorld* World, const FVector& NodeLo
         {
             return FVector::DistSquared(Node.Location, NodeLocation) <= RNM_MapMarkerService::MARKER_LOCATION_TOLERANCE_SQ;
         });
+
+    NodeToClusterMap.Remove(FoundNodeIndex);
 
     // If cluster still has nodes recreate marker
     if (Cluster.Nodes.Num() > 0)

--- a/Source/ResourceNodeMarker/Private/RNM_ClusterManager.cpp
+++ b/Source/ResourceNodeMarker/Private/RNM_ClusterManager.cpp
@@ -6,6 +6,34 @@
 #include "FGMapManager.h"
 #include "FGResourceDescriptor.h"
 
+namespace
+{
+int32 PickMergeTargetClusterIndex(
+    const TArray<FResourceNodeCluster>& Clusters,
+    const TArray<int32>& CandidateIndices)
+{
+    int32 BestIndex = CandidateIndices[0];
+    int32 BestScore = TNumericLimits<int32>::Min();
+
+    for (const int32 Idx : CandidateIndices)
+    {
+        if (!Clusters.IsValidIndex(Idx)) continue;
+
+        int32 Score = Clusters[Idx].Nodes.Num();
+        if (Clusters[Idx].CurrentMarkerGUID.IsValid())
+            Score += 10000;
+
+        if (Score > BestScore)
+        {
+            BestScore = Score;
+            BestIndex = Idx;
+        }
+    }
+
+    return BestIndex;
+}
+}
+
 void URNM_ClusterManager::Initialize(
     const TArray<FResourceNodeInfo>& InResourceNodes,
     const TMap<FIntVector, TArray<int32>>& InSpatialGrid,
@@ -278,11 +306,11 @@ void URNM_ClusterManager::MergeClusters(UWorld* World, int32 TargetIndex, int32 
         if (AFGMapManager* MapManager = AFGMapManager::Get(World))
         {
             MapManager->Authority_RemoveMapMarkerByID(SourceCluster.CurrentMarkerGUID);
+            SourceCluster.CurrentMarkerGUID.Invalidate();
             UE_LOG(LogResourceNodeMarker, Log,
                 TEXT("RNM_ClusterManager: Removed merged-away cluster marker for %s"),
                 *SourceCluster.ResourceName.ToString());
         }
-        SourceCluster.CurrentMarkerGUID.Invalidate();
     }
 
     // Remap all nodes from source to target
@@ -303,8 +331,6 @@ void URNM_ClusterManager::OnNodeDiscovered(UWorld* World, int32 NodeIndex)
 
     const FResourceNodeInfo& NewNode = (*ResourceNodes)[NodeIndex];
 
-    DiscoveredNodeIndices.Add(NodeIndex);
-
     if (!FResourceNodeMarker_ConfigStruct::IsClusteringEnabled(Config))
     {
         FResourceNodeCluster NewCluster;
@@ -321,11 +347,17 @@ void URNM_ClusterManager::OnNodeDiscovered(UWorld* World, int32 NodeIndex)
             World, DiscoveredClusters[ClusterIndex], ResourceVisuals, Config, NewGUID))
         {
             DiscoveredClusters[ClusterIndex].CurrentMarkerGUID = NewGUID;
-        }
+            DiscoveredNodeIndices.Add(NodeIndex);
 
-        UE_LOG(LogResourceNodeMarker, Log,
-            TEXT("RNM_ClusterManager: Per-node marker (clustering off) for %s"),
-            *NewNode.ResourceName.ToString());
+            UE_LOG(LogResourceNodeMarker, Log,
+                TEXT("RNM_ClusterManager: Per-node marker (clustering off) for %s"),
+                *NewNode.ResourceName.ToString());
+        }
+        else
+        {
+            NodeToClusterMap.Remove(NodeIndex);
+            DiscoveredClusters.RemoveAt(ClusterIndex);
+        }
         return;
     }
 
@@ -364,11 +396,17 @@ void URNM_ClusterManager::OnNodeDiscovered(UWorld* World, int32 NodeIndex)
             World, DiscoveredClusters[ClusterIndex], ResourceVisuals, Config, NewGUID))
         {
             DiscoveredClusters[ClusterIndex].CurrentMarkerGUID = NewGUID;
-        }
+            DiscoveredNodeIndices.Add(NodeIndex);
 
-        UE_LOG(LogResourceNodeMarker, Log,
-            TEXT("RNM_ClusterManager: New solo cluster for %s"),
-            *NewNode.ResourceName.ToString());
+            UE_LOG(LogResourceNodeMarker, Log,
+                TEXT("RNM_ClusterManager: New solo cluster for %s"),
+                *NewNode.ResourceName.ToString());
+        }
+        else
+        {
+            NodeToClusterMap.Remove(NodeIndex);
+            DiscoveredClusters.RemoveAt(ClusterIndex);
+        }
     }
     else if (NeighborClusterIndices.Num() == 1)
     {
@@ -383,23 +421,34 @@ void URNM_ClusterManager::OnNodeDiscovered(UWorld* World, int32 NodeIndex)
             World, DiscoveredClusters[ClusterIndex], ResourceVisuals, Config, NewGUID))
         {
             DiscoveredClusters[ClusterIndex].CurrentMarkerGUID = NewGUID;
-        }
+            DiscoveredNodeIndices.Add(NodeIndex);
 
-        UE_LOG(LogResourceNodeMarker, Log,
-            TEXT("RNM_ClusterManager: Added node to cluster for %s (%d nodes)"),
-            *NewNode.ResourceName.ToString(),
-            DiscoveredClusters[ClusterIndex].Nodes.Num());
+            UE_LOG(LogResourceNodeMarker, Log,
+                TEXT("RNM_ClusterManager: Added node to cluster for %s (%d nodes)"),
+                *NewNode.ResourceName.ToString(),
+                DiscoveredClusters[ClusterIndex].Nodes.Num());
+        }
+        else
+        {
+            DiscoveredClusters[ClusterIndex].Nodes.Pop();
+            DiscoveredClusters[ClusterIndex].RecalculateCenter();
+            DiscoveredClusters[ClusterIndex].RecalculateDominantPurity();
+            NodeToClusterMap.Remove(NodeIndex);
+        }
     }
     else
     {
         TArray<int32> ClusterIndices = NeighborClusterIndices.Array();
-        int32 TargetClusterIndex = ClusterIndices[0];
+        const int32 TargetClusterIndex = PickMergeTargetClusterIndex(DiscoveredClusters, ClusterIndices);
 
         DiscoveredClusters[TargetClusterIndex].Nodes.Add(NewNode);
         NodeToClusterMap.Add(NodeIndex, TargetClusterIndex);
 
-        for (int32 i = 1; i < ClusterIndices.Num(); i++)
-            MergeClusters(World, TargetClusterIndex, ClusterIndices[i]);
+        for (const int32 SourceIndex : ClusterIndices)
+        {
+            if (SourceIndex != TargetClusterIndex)
+                MergeClusters(World, TargetClusterIndex, SourceIndex);
+        }
 
         DiscoveredClusters[TargetClusterIndex].RecalculateCenter();
         DiscoveredClusters[TargetClusterIndex].RecalculateDominantPurity();
@@ -409,19 +458,22 @@ void URNM_ClusterManager::OnNodeDiscovered(UWorld* World, int32 NodeIndex)
             World, DiscoveredClusters[TargetClusterIndex], ResourceVisuals, Config, NewGUID))
         {
             DiscoveredClusters[TargetClusterIndex].CurrentMarkerGUID = NewGUID;
+            DiscoveredNodeIndices.Add(NodeIndex);
+
+            UE_LOG(LogResourceNodeMarker, Log,
+                TEXT("RNM_ClusterManager: Merged %d clusters for %s (%d nodes)"),
+                ClusterIndices.Num(),
+                *NewNode.ResourceName.ToString(),
+                DiscoveredClusters[TargetClusterIndex].Nodes.Num());
         }
-
-        UE_LOG(LogResourceNodeMarker, Log,
-            TEXT("RNM_ClusterManager: Merged %d clusters for %s (%d nodes)"),
-            ClusterIndices.Num(),
-            *NewNode.ResourceName.ToString(),
-            DiscoveredClusters[TargetClusterIndex].Nodes.Num());
+        else
+        {
+            UE_LOG(LogResourceNodeMarker, Warning,
+                TEXT("RNM_ClusterManager: Merge succeeded but marker create failed for %s"),
+                *NewNode.ResourceName.ToString());
+            DiscoveredNodeIndices.Add(NodeIndex);
+        }
     }
-}
-
-void URNM_ClusterManager::MarkNodeDiscovered(int32 NodeIndex)
-{
-    DiscoveredNodeIndices.Add(NodeIndex);
 }
 
 void URNM_ClusterManager::OnExtractorPlaced(UWorld* World, const FVector& NodeLocation)

--- a/Source/ResourceNodeMarker/Private/RNM_MapMarkerService.cpp
+++ b/Source/ResourceNodeMarker/Private/RNM_MapMarkerService.cpp
@@ -17,6 +17,7 @@ bool RNM_MapMarkerService::CreateOrUpdateClusterMarker(
     if (!MapManager) return false;
 
     const bool bIsUpdate = Cluster.CurrentMarkerGUID.IsValid();
+    const FGuid PreviousMarkerGUID = Cluster.CurrentMarkerGUID;
     if (!bIsUpdate && !MapManager->CanAddNewMapMarker())
     {
         UE_LOG(LogResourceNodeMarker, Warning,
@@ -24,16 +25,6 @@ bool RNM_MapMarkerService::CreateOrUpdateClusterMarker(
             MapManager->GetMaxNumMapMarkers(),
             *Cluster.ResourceName.ToString());
         return false;
-    }
-
-    // Delete existing marker if this cluster already has one
-    if (bIsUpdate)
-    {
-        MapManager->Authority_RemoveMapMarkerByID(Cluster.CurrentMarkerGUID);
-        Cluster.CurrentMarkerGUID.Invalidate();
-        UE_LOG(LogResourceNodeMarker, Log,
-            TEXT("RNM_MapMarkerService: Removed existing cluster marker for %s"),
-            *Cluster.ResourceName.ToString());
     }
 
     TSubclassOf<UFGResourceDescriptor> ResClass = nullptr;
@@ -85,6 +76,14 @@ bool RNM_MapMarkerService::CreateOrUpdateClusterMarker(
     }
 
     OutGUID = CreatedMarker.MarkerGUID;
+
+    if (PreviousMarkerGUID.IsValid() && PreviousMarkerGUID != OutGUID)
+    {
+        MapManager->Authority_RemoveMapMarkerByID(PreviousMarkerGUID);
+        UE_LOG(LogResourceNodeMarker, Log,
+            TEXT("RNM_MapMarkerService: Removed existing cluster marker for %s"),
+            *Cluster.ResourceName.ToString());
+    }
 
     UE_LOG(LogResourceNodeMarker, Log,
         TEXT("RNM_MapMarkerService: Cluster marker created for %s (%d nodes)"),

--- a/Source/ResourceNodeMarker/Private/RNM_MapMarkerService.cpp
+++ b/Source/ResourceNodeMarker/Private/RNM_MapMarkerService.cpp
@@ -16,8 +16,18 @@ bool RNM_MapMarkerService::CreateOrUpdateClusterMarker(
     AFGMapManager* MapManager = AFGMapManager::Get(World);
     if (!MapManager) return false;
 
+    const bool bIsUpdate = Cluster.CurrentMarkerGUID.IsValid();
+    if (!bIsUpdate && !MapManager->CanAddNewMapMarker())
+    {
+        UE_LOG(LogResourceNodeMarker, Warning,
+            TEXT("RNM_MapMarkerService: Map marker limit reached (%d), skipping marker for %s"),
+            MapManager->GetMaxNumMapMarkers(),
+            *Cluster.ResourceName.ToString());
+        return false;
+    }
+
     // Delete existing marker if this cluster already has one
-    if (Cluster.CurrentMarkerGUID.IsValid())
+    if (bIsUpdate)
     {
         MapManager->Authority_RemoveMapMarkerByID(Cluster.CurrentMarkerGUID);
         Cluster.CurrentMarkerGUID.Invalidate();
@@ -61,15 +71,6 @@ bool RNM_MapMarkerService::CreateOrUpdateClusterMarker(
     case RP_Normal: Marker.Color = Visual.NormalColor; break;
     case RP_Inpure: Marker.Color = Visual.ImpureColor; break;
     default:        Marker.Color = FLinearColor::White; break;
-    }
-
-    if (!MapManager->CanAddNewMapMarker())
-    {
-        UE_LOG(LogResourceNodeMarker, Warning,
-            TEXT("RNM_MapMarkerService: Map marker limit reached (%d), skipping marker for %s"),
-            MapManager->GetMaxNumMapMarkers(),
-            *Cluster.ResourceName.ToString());
-        return false;
     }
 
     FMapMarker CreatedMarker;

--- a/Source/ResourceNodeMarker/Private/RNM_MapMarkerService.cpp
+++ b/Source/ResourceNodeMarker/Private/RNM_MapMarkerService.cpp
@@ -77,6 +77,7 @@ bool RNM_MapMarkerService::CreateOrUpdateClusterMarker(
 
     OutGUID = CreatedMarker.MarkerGUID;
 
+    // Previous marker removed only after add succeeds; brief overlap stays under the 250 cap.
     if (PreviousMarkerGUID.IsValid() && PreviousMarkerGUID != OutGUID)
     {
         MapManager->Authority_RemoveMapMarkerByID(PreviousMarkerGUID);

--- a/Source/ResourceNodeMarker/Private/RNM_MapMarkerService.cpp
+++ b/Source/ResourceNodeMarker/Private/RNM_MapMarkerService.cpp
@@ -63,6 +63,15 @@ bool RNM_MapMarkerService::CreateOrUpdateClusterMarker(
     default:        Marker.Color = FLinearColor::White; break;
     }
 
+    if (!MapManager->CanAddNewMapMarker())
+    {
+        UE_LOG(LogResourceNodeMarker, Warning,
+            TEXT("RNM_MapMarkerService: Map marker limit reached (%d), skipping marker for %s"),
+            MapManager->GetMaxNumMapMarkers(),
+            *Cluster.ResourceName.ToString());
+        return false;
+    }
+
     FMapMarker CreatedMarker;
     bool bSuccess = MapManager->AddNewMapMarker(Marker, CreatedMarker);
 

--- a/Source/ResourceNodeMarker/Private/RNM_NodeScanner.cpp
+++ b/Source/ResourceNodeMarker/Private/RNM_NodeScanner.cpp
@@ -32,22 +32,26 @@ void RNM_NodeScanner::ScanNodes(UWorld* World, TArray<FResourceNodeInfo>& OutNod
         TEXT("RNM_NodeScanner: Found %d extractable unoccupied nodes"), OutNodes.Num());
 }
 
-FIntVector RNM_NodeScanner::GetGridCell(const FVector& Location)
+FIntVector RNM_NodeScanner::GetGridCell(const FVector& Location, const float CellSizeCm)
 {
+    const float SafeCellSize = FMath::Max(CellSizeCm, 1.0f);
     return FIntVector(
-        FMath::FloorToInt(Location.X / CLUSTER_RADIUS),
-        FMath::FloorToInt(Location.Y / CLUSTER_RADIUS),
+        FMath::FloorToInt(Location.X / SafeCellSize),
+        FMath::FloorToInt(Location.Y / SafeCellSize),
         0 // 2D grid, Z handled separately via distance check
     );
 }
 
-void RNM_NodeScanner::BuildSpatialGrid(const TArray<FResourceNodeInfo>& Nodes, TMap<FIntVector, TArray<int32>>& OutGrid)
+void RNM_NodeScanner::BuildSpatialGrid(
+    const TArray<FResourceNodeInfo>& Nodes,
+    TMap<FIntVector, TArray<int32>>& OutGrid,
+    const float CellSizeCm)
 {
     OutGrid.Reset();
 
     for (int32 i = 0; i < Nodes.Num(); i++)
     {
-        FIntVector Cell = GetGridCell(Nodes[i].Location);
+        FIntVector Cell = GetGridCell(Nodes[i].Location, CellSizeCm);
         OutGrid.FindOrAdd(Cell).Add(i);
     }
 

--- a/Source/ResourceNodeMarker/Private/RNM_ResourceVisuals.cpp
+++ b/Source/ResourceNodeMarker/Private/RNM_ResourceVisuals.cpp
@@ -37,11 +37,12 @@ int32 GetStampIconIdForOreOrFluid(TSubclassOf<UFGResourceDescriptor> ResClass)
 /** When bUseIcons is true and visuals miss: map descriptor class names to in-game map icon IDs (FIconsPreset). */
 int32 ResolveInGameIconIdFromResourceClass(TSubclassOf<UFGResourceDescriptor> ResClass)
 {
-    if (!ResClass) return 656;
+    FStampPreset Sp;
+    if (!ResClass) return Sp.QuestionMark;
 
     const EResourceForm Form = UFGItemDescriptor::GetForm(ResClass);
     if (Form == EResourceForm::RF_LIQUID || Form == EResourceForm::RF_GAS)
-        return 657;
+        return Sp.Fluids;
 
     const FString S = ResClass->GetName();
     FIconsPreset Ip;
@@ -57,7 +58,6 @@ int32 ResolveInGameIconIdFromResourceClass(TSubclassOf<UFGResourceDescriptor> Re
     if (S.Contains(TEXT("Caterium"))) return Ip.Caterium;
     if (S.Contains(TEXT("Sam"))) return Ip.Sam;
 
-    FStampPreset Sp;
     return Sp.Rock;
 }
 }

--- a/Source/ResourceNodeMarker/Private/RNM_WorldSubsystem.cpp
+++ b/Source/ResourceNodeMarker/Private/RNM_WorldSubsystem.cpp
@@ -20,14 +20,6 @@ void URNM_WorldSubsystem::Initialize(FSubsystemCollectionBase& Collection)
     World->OnWorldBeginPlay.AddUObject(this, &URNM_WorldSubsystem::InitializeConfig);
     World->OnWorldBeginPlay.AddUObject(this, &URNM_WorldSubsystem::BindBuildableDelegate);
 
-    World->GetTimerManager().SetTimer(
-        ProximityTimerHandle,
-        this,
-        &URNM_WorldSubsystem::CheckPlayerProximity,
-        0.25f,
-        true
-    );
-
     ResourceVisuals = NewObject<URNM_ResourceVisuals>(this);
     ClusterManager = NewObject<URNM_ClusterManager>(this);
 }
@@ -60,14 +52,28 @@ void URNM_WorldSubsystem::InitializeConfig()
     UE_LOG(LogResourceNodeMarker, Log, TEXT("RNM: Extractor Marker Behavior: %d (%s)"),
         ConfigData.ExtractorMarkerBehavior,
         ConfigData.ExtractorMarkerBehavior == 0 ? TEXT("Keep") :
-        ConfigData.ExtractorMarkerBehavior == 1 ? TEXT("Remove") :
-        ConfigData.ExtractorMarkerBehavior == 2 ? TEXT("Highlight") : TEXT("Invalid"));
+        ConfigData.ExtractorMarkerBehavior == 1 ? TEXT("Remove") : TEXT("Invalid"));
     UE_LOG(LogResourceNodeMarker, Log, TEXT("RNM: --- Icon Settings ---"));
     UE_LOG(LogResourceNodeMarker, Log, TEXT("RNM: Use Icons: %s"), ConfigData.bUseIcons ? TEXT("YES") : TEXT("NO"));
     UE_LOG(LogResourceNodeMarker, Log, TEXT("RNM: --- Clustering ---"));
-    UE_LOG(LogResourceNodeMarker, Log, TEXT("RNM: Cluster nodes: %s"), ConfigData.bClusterNodes ? TEXT("YES (shared markers)") : TEXT("NO (one marker per node)"));
+    UE_LOG(LogResourceNodeMarker, Log, TEXT("RNM: Cluster Radius: %.0fm"), ConfigData.ClusterRadius);
+    UE_LOG(LogResourceNodeMarker, Log, TEXT("RNM: Cluster Height Tolerance: %.0fm"), ConfigData.ClusterHeightTolerance);
+    UE_LOG(LogResourceNodeMarker, Log, TEXT("RNM: Cluster nodes: %s"),
+        FResourceNodeMarker_ConfigStruct::IsClusteringEnabled(ConfigData)
+            ? TEXT("YES (shared markers)") : TEXT("NO (one marker per node)"));
 
     ScanAllNodes();
+
+    if (UWorld* World = GetWorld())
+    {
+        World->GetTimerManager().SetTimer(
+            ProximityTimerHandle,
+            this,
+            &URNM_WorldSubsystem::CheckPlayerProximity,
+            0.25f,
+            true
+        );
+    }
 }
 
 void URNM_WorldSubsystem::ScanAllNodes()
@@ -75,7 +81,8 @@ void URNM_WorldSubsystem::ScanAllNodes()
     UWorld* World = GetWorld();
 
     RNM_NodeScanner::ScanNodes(World, ResourceNodes);
-    RNM_NodeScanner::BuildSpatialGrid(ResourceNodes, SpatialGrid);
+    const float GridCellSizeCm = FResourceNodeMarker_ConfigStruct::GetClusterRadiusCm(ConfigData);
+    RNM_NodeScanner::BuildSpatialGrid(ResourceNodes, SpatialGrid, GridCellSizeCm);
 
     ClusterManager->Initialize(ResourceNodes, SpatialGrid, ResourceVisuals, ConfigData);
     ClusterManager->RebuildClustersFromExistingMarkers(World);
@@ -89,6 +96,8 @@ void URNM_WorldSubsystem::ScanAllNodes()
 
 void URNM_WorldSubsystem::CheckPlayerProximity()
 {
+    if (!bConfigLoaded || !ClusterManager) return;
+
     UWorld* World = GetWorld();
     if (!World) return;
 
@@ -106,17 +115,16 @@ void URNM_WorldSubsystem::CheckPlayerProximity()
             continue;
 
         const FResourceNodeInfo& NodeInfo = ResourceNodes[i];
-        if (!IsValid(NodeInfo.NodeActor)) continue;
+        AFGResourceNode* Node = NodeInfo.NodeActor;
+        if (!IsValid(Node)) continue;
+        if (Node->IsOccupied()) continue;
 
-        if (bConfigLoaded)
-        {
-            const bool bPurityEnabled =
-                (NodeInfo.Purity == RP_Pure && ConfigData.bMarkPure) ||
-                (NodeInfo.Purity == RP_Normal && ConfigData.bMarkNormal) ||
-                (NodeInfo.Purity == RP_Inpure && ConfigData.bMarkImpure);
+        const bool bPurityEnabled =
+            (NodeInfo.Purity == RP_Pure && ConfigData.bMarkPure) ||
+            (NodeInfo.Purity == RP_Normal && ConfigData.bMarkNormal) ||
+            (NodeInfo.Purity == RP_Inpure && ConfigData.bMarkImpure);
 
-            if (!bPurityEnabled) continue;
-        }
+        if (!bPurityEnabled) continue;
 
         if (FVector::DistSquared(PlayerLocation, NodeInfo.Location) <= PlayerProximityThresholdSq)
         {
@@ -152,7 +160,7 @@ void URNM_WorldSubsystem::OnBuildableConstructed(AFGBuildable* Buildable)
     AFGBuildableResourceExtractor* Extractor = Cast<AFGBuildableResourceExtractor>(Buildable);
     if (!Extractor) return;
 
-    if (ConfigData.ExtractorMarkerBehavior == 0) return;
+    if (ConfigData.ExtractorMarkerBehavior != 1) return;
 
     TScriptInterface<IFGExtractableResourceInterface> ExtractableResource = Extractor->GetExtractableResource();
     if (!ExtractableResource) return;

--- a/Source/ResourceNodeMarker/Private/RNM_WorldSubsystem.cpp
+++ b/Source/ResourceNodeMarker/Private/RNM_WorldSubsystem.cpp
@@ -79,6 +79,7 @@ void URNM_WorldSubsystem::InitializeConfig()
 void URNM_WorldSubsystem::ScanAllNodes()
 {
     UWorld* World = GetWorld();
+    if (!World || !ClusterManager || !ResourceVisuals) return;
 
     RNM_NodeScanner::ScanNodes(World, ResourceNodes);
     const float GridCellSizeCm = FResourceNodeMarker_ConfigStruct::GetClusterRadiusCm(ConfigData);
@@ -155,7 +156,7 @@ void URNM_WorldSubsystem::BindBuildableDelegate()
 
 void URNM_WorldSubsystem::OnBuildableConstructed(AFGBuildable* Buildable)
 {
-    if (!Buildable) return;
+    if (!Buildable || !bConfigLoaded || !ClusterManager) return;
 
     AFGBuildableResourceExtractor* Extractor = Cast<AFGBuildableResourceExtractor>(Buildable);
     if (!Extractor) return;

--- a/Source/ResourceNodeMarker/Private/ResourceNodeMarker_ConfigStruct.cpp
+++ b/Source/ResourceNodeMarker/Private/ResourceNodeMarker_ConfigStruct.cpp
@@ -1,0 +1,44 @@
+#include "ResourceNodeMarker_ConfigStruct.h"
+#include "ResourceNodeMarker.h"
+
+void FResourceNodeMarker_ConfigStruct::NormalizeLegacyValues(FResourceNodeMarker_ConfigStruct& Config)
+{
+    // Legacy Highlight enum value — treat as Remove until UE asset drops the entry
+    if (Config.ExtractorMarkerBehavior == 2)
+        Config.ExtractorMarkerBehavior = 1;
+}
+
+FResourceNodeMarker_ConfigStruct FResourceNodeMarker_ConfigStruct::GetActiveConfig(UObject* WorldContext)
+{
+    FResourceNodeMarker_ConfigStruct ConfigStruct{};
+    FConfigId ConfigId{"ResourceNodeMarker", ""};
+
+    const UWorld* World = GEngine->GetWorldFromContextObject(WorldContext, EGetWorldErrorMode::ReturnNull);
+    if (!World)
+    {
+        UE_LOG(LogResourceNodeMarker, Warning,
+            TEXT("RNM: GetActiveConfig called without a valid world; using default config"));
+        return ConfigStruct;
+    }
+
+    UGameInstance* GameInstance = World->GetGameInstance();
+    if (!GameInstance)
+    {
+        UE_LOG(LogResourceNodeMarker, Warning,
+            TEXT("RNM: GetActiveConfig: no GameInstance; using default config"));
+        return ConfigStruct;
+    }
+
+    UConfigManager* ConfigManager = GameInstance->GetSubsystem<UConfigManager>();
+    if (!ConfigManager)
+    {
+        UE_LOG(LogResourceNodeMarker, Warning,
+            TEXT("RNM: GetActiveConfig: UConfigManager not found; using default config"));
+        return ConfigStruct;
+    }
+
+    ConfigManager->FillConfigurationStruct(ConfigId, FDynamicStructInfo{
+        FResourceNodeMarker_ConfigStruct::StaticStruct(), &ConfigStruct});
+    NormalizeLegacyValues(ConfigStruct);
+    return ConfigStruct;
+}

--- a/Source/ResourceNodeMarker/Private/ResourceNodeMarker_ConfigStruct.cpp
+++ b/Source/ResourceNodeMarker/Private/ResourceNodeMarker_ConfigStruct.cpp
@@ -37,6 +37,14 @@ FResourceNodeMarker_ConfigStruct FResourceNodeMarker_ConfigStruct::GetActiveConf
         return ConfigStruct;
     }
 
+    if (!ConfigManager->GetConfigurationById(ConfigId))
+    {
+        UE_LOG(LogResourceNodeMarker, Warning,
+            TEXT("RNM: GetActiveConfig: config '%s' not registered; using default config"),
+            *ConfigId.ModReference);
+        return ConfigStruct;
+    }
+
     ConfigManager->FillConfigurationStruct(ConfigId, FDynamicStructInfo{
         FResourceNodeMarker_ConfigStruct::StaticStruct(), &ConfigStruct});
     NormalizeLegacyValues(ConfigStruct);

--- a/Source/ResourceNodeMarker/Public/RNM_ClusterManager.h
+++ b/Source/ResourceNodeMarker/Public/RNM_ClusterManager.h
@@ -58,7 +58,8 @@ public:
      void OnExtractorPlaced(UWorld* World, const FVector& NodeLocation);
 
 private:
-    void MergeClusters(UWorld* World, int32 TargetIndex, int32 SourceIndex);
+    bool MergeClusters(UWorld* World, int32 TargetIndex, int32 SourceIndex, bool bRemoveSourceMarker = true);
+    bool TryRemoveClusterMapMarker(UWorld* World, FResourceNodeCluster& Cluster);
     void ApplySoloClusteringLayoutIfNeeded();
     int32 FindResourceNodeIndex(const FResourceNodeInfo& Info) const;
 

--- a/Source/ResourceNodeMarker/Public/RNM_ClusterManager.h
+++ b/Source/ResourceNodeMarker/Public/RNM_ClusterManager.h
@@ -2,6 +2,7 @@
 #include "CoreMinimal.h"
 #include "RNM_ResourceNodeInfo.h"
 #include "RNM_ResourceVisuals.h"
+#include "RNM_NodeScanner.h"
 #include "ResourceNodeMarker_ConfigStruct.h"
 #include "FGMapManager.h"
 #include "RNM_ClusterManager.generated.h"
@@ -59,12 +60,13 @@ public:
      void OnExtractorPlaced(UWorld* World, const FVector& NodeLocation);
 
 private:
-    void MergeClusters(int32 TargetIndex, int32 SourceIndex);
+    void MergeClusters(UWorld* World, int32 TargetIndex, int32 SourceIndex);
     void ApplySoloClusteringLayoutIfNeeded();
     int32 FindResourceNodeIndex(const FResourceNodeInfo& Info) const;
 
     float ClusterRadiusSq = 0.0f;
     float ClusterHeightTolerance = 0.0f;
+    float GridCellSizeCm = RNM_NodeScanner::DEFAULT_CLUSTER_RADIUS_CM;
 
 private:
     // References to subsystem-owned data

--- a/Source/ResourceNodeMarker/Public/RNM_ClusterManager.h
+++ b/Source/ResourceNodeMarker/Public/RNM_ClusterManager.h
@@ -50,8 +50,6 @@ public:
     /** Returns true if the node at the given index has already been discovered. */
     bool IsNodeDiscovered(int32 NodeIndex) const;
 
-    void MarkNodeDiscovered(int32 NodeIndex);
-
     /**
      * Called when an extractor is placed on a node.
      * Marks node as discovered, removes it from its cluster,

--- a/Source/ResourceNodeMarker/Public/RNM_MapMarkerService.h
+++ b/Source/ResourceNodeMarker/Public/RNM_MapMarkerService.h
@@ -15,7 +15,7 @@ public:
 
     /**
      * Creates or updates a cluster marker.
-     * If the cluster has an existing marker (CurrentMarkerGUID is valid), it will be deleted first.
+     * When updating, adds the new marker first and removes the previous one only on success.
      * @param World - The game world.
      * @param Cluster - The cluster to create a marker for.
      * @param ResourceVisuals - Visual lookup helper.

--- a/Source/ResourceNodeMarker/Public/RNM_NodeScanner.h
+++ b/Source/ResourceNodeMarker/Public/RNM_NodeScanner.h
@@ -23,19 +23,19 @@ public:
      * @param Nodes - The scanned nodes to index.
      * @param OutGrid - Map of grid cell to node indices.
      */
-    static void BuildSpatialGrid(const TArray<FResourceNodeInfo>& Nodes, TMap<FIntVector, TArray<int32>>& OutGrid);
+    static void BuildSpatialGrid(
+        const TArray<FResourceNodeInfo>& Nodes,
+        TMap<FIntVector, TArray<int32>>& OutGrid,
+        float CellSizeCm);
 
-    /**
-     * Returns the grid cell for a given world location.
-     */
-    static FIntVector GetGridCell(const FVector& Location);
+    /** Returns the grid cell for a given world location. CellSizeCm should match Config.ClusterRadius * 100. */
+    static FIntVector GetGridCell(const FVector& Location, float CellSizeCm);
 
     /**
      * Returns all node indices in the given cell and its 8 neighbors.
      */
     static TArray<int32> GetNeighborCellIndices(const TMap<FIntVector, TArray<int32>>& Grid, const FIntVector& Cell);
 
-    // Cluster radius — max distance between two nodes to be considered neighbors
-    static constexpr float CLUSTER_RADIUS = 25000.0f; // 250m in cm
-    static constexpr float CLUSTER_RADIUS_SQ = CLUSTER_RADIUS * CLUSTER_RADIUS;
+    /** Default cluster radius when config is unavailable (250m in cm). */
+    static constexpr float DEFAULT_CLUSTER_RADIUS_CM = 25000.0f;
 };

--- a/Source/ResourceNodeMarker/Public/ResourceNodeMarker_ConfigStruct.h
+++ b/Source/ResourceNodeMarker/Public/ResourceNodeMarker_ConfigStruct.h
@@ -2,6 +2,7 @@
 #include "CoreMinimal.h"
 #include "Configuration/ConfigManager.h"
 #include "Engine/Engine.h"
+#include "ResourceNodeMarker.h"
 #include "ResourceNodeMarker_ConfigStruct.generated.h"
 
 /* Struct generated from Mod Configuration Asset '/ResourceNodeMarker/ResourceNodeMarker_Config' */
@@ -27,7 +28,7 @@ public:
     int32 CompassViewDistance = 2; // 2 = Mid
 
     UPROPERTY(BlueprintReadWrite)
-    int32 ExtractorMarkerBehavior = 0; // 0 = Keep, 1 = Remove
+    int32 ExtractorMarkerBehavior = 0; // 0 = Keep, 1 = Remove marker when extractor placed
 
     /**
      * When false: map markers use stock stamps only — rock for solid resources, fluid/drop stamp for liquids and gases.
@@ -43,20 +44,59 @@ public:
     float ClusterHeightTolerance = 100.0f; // meters, converted to cm in code
 
     /**
-     * When true (default), nearby nodes of the same resource share one map marker (clustering).
+     * When true (default), nearby nodes of the same resource share one map marker.
      * When false, each node gets its own marker.
+     * UE config: BP_ConfigPropertyBool checkbox (same pattern as bMarkPure / bUseIcons).
+     * SML reads config once at world begin play — reload required to apply changes.
      */
     UPROPERTY(BlueprintReadWrite)
     bool bClusterNodes = true;
+
+    static float GetClusterRadiusCm(const FResourceNodeMarker_ConfigStruct& Config)
+    {
+        return FMath::Max(Config.ClusterRadius * 100.0f, 1.0f);
+    }
+
+    static float GetClusterHeightToleranceCm(const FResourceNodeMarker_ConfigStruct& Config)
+    {
+        return FMath::Max(Config.ClusterHeightTolerance * 100.0f, 0.0f);
+    }
+
+    static bool IsClusteringEnabled(const FResourceNodeMarker_ConfigStruct& Config)
+    {
+        return Config.bClusterNodes;
+    }
 
     /* Retrieves active configuration value and returns object of this struct containing it */
     static FResourceNodeMarker_ConfigStruct GetActiveConfig(UObject* WorldContext) {
         FResourceNodeMarker_ConfigStruct ConfigStruct{};
         FConfigId ConfigId{"ResourceNodeMarker", ""};
-        if (const UWorld* World = GEngine->GetWorldFromContextObject(WorldContext, EGetWorldErrorMode::ReturnNull)) {
-            UConfigManager* ConfigManager = World->GetGameInstance()->GetSubsystem<UConfigManager>();
-            ConfigManager->FillConfigurationStruct(ConfigId, FDynamicStructInfo{FResourceNodeMarker_ConfigStruct::StaticStruct(), &ConfigStruct});
+        const UWorld* World = GEngine->GetWorldFromContextObject(WorldContext, EGetWorldErrorMode::ReturnNull);
+        if (!World)
+        {
+            UE_LOG(LogResourceNodeMarker, Warning,
+                TEXT("RNM: GetActiveConfig called without a valid world; using default config"));
+            return ConfigStruct;
         }
+
+        UGameInstance* GameInstance = World->GetGameInstance();
+        if (!GameInstance)
+        {
+            UE_LOG(LogResourceNodeMarker, Warning,
+                TEXT("RNM: GetActiveConfig: no GameInstance; using default config"));
+            return ConfigStruct;
+        }
+
+        UConfigManager* ConfigManager = GameInstance->GetSubsystem<UConfigManager>();
+        if (!ConfigManager)
+        {
+            UE_LOG(LogResourceNodeMarker, Warning,
+                TEXT("RNM: GetActiveConfig: UConfigManager not found; using default config"));
+            return ConfigStruct;
+        }
+
+        ConfigManager->FillConfigurationStruct(ConfigId, FDynamicStructInfo{
+            FResourceNodeMarker_ConfigStruct::StaticStruct(), &ConfigStruct});
         return ConfigStruct;
     }
 };

--- a/Source/ResourceNodeMarker/Public/ResourceNodeMarker_ConfigStruct.h
+++ b/Source/ResourceNodeMarker/Public/ResourceNodeMarker_ConfigStruct.h
@@ -2,7 +2,6 @@
 #include "CoreMinimal.h"
 #include "Configuration/ConfigManager.h"
 #include "Engine/Engine.h"
-#include "ResourceNodeMarker.h"
 #include "ResourceNodeMarker_ConfigStruct.generated.h"
 
 /* Struct generated from Mod Configuration Asset '/ResourceNodeMarker/ResourceNodeMarker_Config' */
@@ -28,7 +27,7 @@ public:
     int32 CompassViewDistance = 2; // 2 = Mid
 
     UPROPERTY(BlueprintReadWrite)
-    int32 ExtractorMarkerBehavior = 0; // 0 = Keep, 1 = Remove marker when extractor placed
+    int32 ExtractorMarkerBehavior = 0; // 0 = Keep, 1 = Remove; legacy 2 (Highlight) normalized to 1 on load
 
     /**
      * When false: map markers use stock stamps only — rock for solid resources, fluid/drop stamp for liquids and gases.
@@ -67,37 +66,9 @@ public:
         return Config.bClusterNodes;
     }
 
-    /* Retrieves active configuration value and returns object of this struct containing it */
-    static FResourceNodeMarker_ConfigStruct GetActiveConfig(UObject* WorldContext) {
-        FResourceNodeMarker_ConfigStruct ConfigStruct{};
-        FConfigId ConfigId{"ResourceNodeMarker", ""};
-        const UWorld* World = GEngine->GetWorldFromContextObject(WorldContext, EGetWorldErrorMode::ReturnNull);
-        if (!World)
-        {
-            UE_LOG(LogResourceNodeMarker, Warning,
-                TEXT("RNM: GetActiveConfig called without a valid world; using default config"));
-            return ConfigStruct;
-        }
+    /** Maps legacy config values after load (e.g. Highlight → Remove). */
+    static void NormalizeLegacyValues(FResourceNodeMarker_ConfigStruct& Config);
 
-        UGameInstance* GameInstance = World->GetGameInstance();
-        if (!GameInstance)
-        {
-            UE_LOG(LogResourceNodeMarker, Warning,
-                TEXT("RNM: GetActiveConfig: no GameInstance; using default config"));
-            return ConfigStruct;
-        }
-
-        UConfigManager* ConfigManager = GameInstance->GetSubsystem<UConfigManager>();
-        if (!ConfigManager)
-        {
-            UE_LOG(LogResourceNodeMarker, Warning,
-                TEXT("RNM: GetActiveConfig: UConfigManager not found; using default config"));
-            return ConfigStruct;
-        }
-
-        ConfigManager->FillConfigurationStruct(ConfigId, FDynamicStructInfo{
-            FResourceNodeMarker_ConfigStruct::StaticStruct(), &ConfigStruct});
-        return ConfigStruct;
-    }
+    static FResourceNodeMarker_ConfigStruct GetActiveConfig(UObject* WorldContext);
 };
 

--- a/Source/ResourceNodeMarker/Public/ResourceNodeMarker_ConfigStruct.h
+++ b/Source/ResourceNodeMarker/Public/ResourceNodeMarker_ConfigStruct.h
@@ -66,7 +66,7 @@ public:
         return Config.bClusterNodes;
     }
 
-    /** Maps legacy config values after load (e.g. Highlight → Remove). */
+    /** Maps legacy config values after load (e.g. Highlight → Remove). Called by GetActiveConfig. */
     static void NormalizeLegacyValues(FResourceNodeMarker_ConfigStruct& Config);
 
     static FResourceNodeMarker_ConfigStruct GetActiveConfig(UObject* WorldContext);


### PR DESCRIPTION
ClusterRadius config was ignored (hardcoded 250m). Merge left orphan map markers. Extractor path stale NodeToClusterMap.

- Drive grid + distance checks from config helpers
- Z tolerance on marker rebuild
- Delete source marker GUID on cluster merge
- NodeToClusterMap.Remove on extractor placement
- Proximity timer after config load; skip occupied nodes
- CanAddNewMapMarker guard (250 cap)
- GetActiveConfig null guards
- ExtractorMarkerBehavior == 1 only (Highlight removed)