### PR TITLE
Rnm fix color non english

### DIFF
--- a/Source/ResourceNodeMarker/Private/RNM_MapMarkerService.cpp
+++ b/Source/ResourceNodeMarker/Private/RNM_MapMarkerService.cpp
@@ -12,6 +12,61 @@ bool IsLegacyRNMCategoryWithoutClassId(const FString& Category)
     return Category == TEXT("RNM::Ore") || Category == TEXT("RNM::Fluid");
 }
 
+void ResolveClusterResourceContext(
+    const FResourceNodeCluster& Cluster,
+    TSubclassOf<UFGResourceDescriptor>& OutResClass,
+    FName& OutLegacyDisplayKey)
+{
+    OutResClass = nullptr;
+    OutLegacyDisplayKey = NAME_None;
+
+    for (const FResourceNodeInfo& N : Cluster.Nodes)
+    {
+        if (!OutResClass && N.ResourceDescriptorClass)
+            OutResClass = N.ResourceDescriptorClass;
+        if (!OutResClass && N.NodeActor)
+            OutResClass = N.NodeActor->GetResourceClass();
+        if (OutLegacyDisplayKey == NAME_None && N.NodeActor)
+            OutLegacyDisplayKey = FName(*N.NodeActor->GetResourceName().ToString());
+    }
+}
+
+bool InferIsFluidResource(const FName ClassKey, TSubclassOf<UFGResourceDescriptor> ResClass, const FResourceVisual& Visual)
+{
+    if (ResClass)
+    {
+        const EResourceForm Form = UFGItemDescriptor::GetForm(ResClass);
+        return Form == EResourceForm::RF_LIQUID || Form == EResourceForm::RF_GAS;
+    }
+
+    const FString ClassStr = ClassKey.ToString();
+    if (ClassStr.Contains(TEXT("Liquid")) || ClassStr.Contains(TEXT("Desc_Water")) || ClassStr.Contains(TEXT("WaterGeyser")))
+        return true;
+
+    FStampPreset Icons;
+    return Visual.IconID == Icons.Fluids;
+}
+
+FString GetClusterResourceDisplayLabel(
+    const FResourceNodeCluster& Cluster,
+    TSubclassOf<UFGResourceDescriptor> ResClass)
+{
+    for (const FResourceNodeInfo& N : Cluster.Nodes)
+    {
+        if (N.NodeActor)
+            return N.NodeActor->GetResourceName().ToString();
+    }
+
+    if (ResClass)
+    {
+        const FText ItemName = UFGItemDescriptor::GetItemName(ResClass);
+        if (!ItemName.IsEmpty())
+            return ItemName.ToString();
+    }
+
+    return Cluster.ResourceName.ToString();
+}
+
 FString GetPurityDisplayLabel(const FResourceNodeCluster& Cluster, const EResourcePurity Purity)
 {
     for (const FResourceNodeInfo& Node : Cluster.Nodes)
@@ -84,25 +139,13 @@ bool RNM_MapMarkerService::CreateOrUpdateClusterMarker(
 
     TSubclassOf<UFGResourceDescriptor> ResClass = nullptr;
     FName LegacyDisplayKey = NAME_None;
-    for (const FResourceNodeInfo& N : Cluster.Nodes)
-    {
-        if (!ResClass && N.ResourceDescriptorClass)
-            ResClass = N.ResourceDescriptorClass;
-        if (!ResClass && N.NodeActor)
-            ResClass = N.NodeActor->GetResourceClass();
-        if (LegacyDisplayKey == NAME_None && N.NodeActor)
-            LegacyDisplayKey = FName(*N.NodeActor->GetResourceName().ToString());
-    }
+    ResolveClusterResourceContext(Cluster, ResClass, LegacyDisplayKey);
 
     // Cluster.ResourceName is descriptor UClass FName (Desc_*_C), not localized display text.
     const FName VisualClassKey = ResClass ? ResClass->GetFName() : Cluster.ResourceName;
     FResourceVisual Visual = ResourceVisuals->GetResourceVisual(
         VisualClassKey, ResClass, Config.bUseIcons, LegacyDisplayKey);
-    FStampPreset Icons;
-    const bool bIsFluid = ResClass
-        ? (UFGItemDescriptor::GetForm(ResClass) == EResourceForm::RF_LIQUID
-            || UFGItemDescriptor::GetForm(ResClass) == EResourceForm::RF_GAS)
-        : (Visual.IconID == Icons.Fluids);
+    const bool bIsFluid = InferIsFluidResource(VisualClassKey, ResClass, Visual);
 
     FMapMarker Marker;
     Marker.MarkerGUID = FGuid::NewGuid();
@@ -186,28 +229,11 @@ FString RNM_MapMarkerService::BuildClusterMarkerName(const FResourceNodeCluster&
         PurityStr += FormatPurityCountSegment(Cluster, ImpureCount, RP_Inpure);
     }
 
-    FString ResourceLabel;
     TSubclassOf<UFGResourceDescriptor> ResClass = nullptr;
-    for (const FResourceNodeInfo& N : Cluster.Nodes)
-    {
-        if (!ResClass && N.ResourceDescriptorClass)
-            ResClass = N.ResourceDescriptorClass;
-        if (N.NodeActor)
-        {
-            if (ResourceLabel.IsEmpty())
-                ResourceLabel = N.NodeActor->GetResourceName().ToString();
-            if (!ResClass)
-                ResClass = N.NodeActor->GetResourceClass();
-        }
-    }
-    if (ResourceLabel.IsEmpty() && ResClass)
-    {
-        const FText ItemName = UFGItemDescriptor::GetItemName(ResClass);
-        if (!ItemName.IsEmpty())
-            ResourceLabel = ItemName.ToString();
-    }
-    if (ResourceLabel.IsEmpty())
-        ResourceLabel = Cluster.ResourceName.ToString();
+    FName UnusedLegacyKey = NAME_None;
+    ResolveClusterResourceContext(Cluster, ResClass, UnusedLegacyKey);
+
+    const FString ResourceLabel = GetClusterResourceDisplayLabel(Cluster, ResClass);
 
     if (PurityStr.IsEmpty())
         return ResourceLabel;

--- a/Source/ResourceNodeMarker/Private/RNM_MapMarkerService.cpp
+++ b/Source/ResourceNodeMarker/Private/RNM_MapMarkerService.cpp
@@ -22,7 +22,7 @@ FString GetPurityDisplayLabel(const FResourceNodeCluster& Cluster, const EResour
         const FText GameLabel = Node.NodeActor->GetResoucePurityText();
         if (!GameLabel.IsEmpty())
             return GameLabel.ToString();
-        break;
+        continue;
     }
 
     if (const UEnum* PurityEnum = StaticEnum<EResourcePurity>())
@@ -120,7 +120,7 @@ bool RNM_MapMarkerService::CreateOrUpdateClusterMarker(
     case RP_Pure:   Marker.Color = Visual.PureColor;   break;
     case RP_Normal: Marker.Color = Visual.NormalColor; break;
     case RP_Inpure: Marker.Color = Visual.ImpureColor; break;
-    default:        Marker.Color = FLinearColor::White; break;
+    default:        Marker.Color = Visual.NormalColor; break;
     }
 
     FMapMarker CreatedMarker;
@@ -187,13 +187,24 @@ FString RNM_MapMarkerService::BuildClusterMarkerName(const FResourceNodeCluster&
     }
 
     FString ResourceLabel;
+    TSubclassOf<UFGResourceDescriptor> ResClass = nullptr;
     for (const FResourceNodeInfo& N : Cluster.Nodes)
     {
+        if (!ResClass && N.ResourceDescriptorClass)
+            ResClass = N.ResourceDescriptorClass;
         if (N.NodeActor)
         {
-            ResourceLabel = N.NodeActor->GetResourceName().ToString();
-            break;
+            if (ResourceLabel.IsEmpty())
+                ResourceLabel = N.NodeActor->GetResourceName().ToString();
+            if (!ResClass)
+                ResClass = N.NodeActor->GetResourceClass();
         }
+    }
+    if (ResourceLabel.IsEmpty() && ResClass)
+    {
+        const FText ItemName = UFGItemDescriptor::GetItemName(ResClass);
+        if (!ItemName.IsEmpty())
+            ResourceLabel = ItemName.ToString();
     }
     if (ResourceLabel.IsEmpty())
         ResourceLabel = Cluster.ResourceName.ToString();

--- a/Source/ResourceNodeMarker/Private/RNM_MapMarkerService.cpp
+++ b/Source/ResourceNodeMarker/Private/RNM_MapMarkerService.cpp
@@ -3,6 +3,41 @@
 #include "FGItemDescriptor.h"
 #include "FGMapManager.h"
 #include "FGResourceDescriptor.h"
+#include "FGResourceNode.h"
+
+namespace
+{
+bool IsLegacyRNMCategoryWithoutClassId(const FString& Category)
+{
+    return Category == TEXT("RNM::Ore") || Category == TEXT("RNM::Fluid");
+}
+
+FString FormatLocalizedPurityCount(const int32 Count, const EResourcePurity Purity)
+{
+    if (Count <= 0) return FString();
+
+    FString Label;
+    if (const UEnum* PurityEnum = StaticEnum<EResourcePurity>())
+    {
+        const int64 EnumValue = static_cast<int64>(Purity);
+        if (PurityEnum->IsValidEnumValue(EnumValue))
+            Label = PurityEnum->GetDisplayNameTextByValue(EnumValue).ToString();
+    }
+
+    if (Label.IsEmpty())
+    {
+        switch (Purity)
+        {
+        case RP_Pure:   Label = TEXT("Pure"); break;
+        case RP_Normal: Label = TEXT("Normal"); break;
+        case RP_Inpure: Label = TEXT("Impure"); break;
+        default:        return FString();
+        }
+    }
+
+    return FString::Printf(TEXT("%d %s"), Count, *Label);
+}
+}
 
 bool RNM_MapMarkerService::CreateOrUpdateClusterMarker(
     UWorld* World,
@@ -33,12 +68,15 @@ bool RNM_MapMarkerService::CreateOrUpdateClusterMarker(
     {
         if (!ResClass && N.ResourceDescriptorClass)
             ResClass = N.ResourceDescriptorClass;
+        if (!ResClass && N.NodeActor)
+            ResClass = N.NodeActor->GetResourceClass();
         if (LegacyDisplayKey == NAME_None && N.NodeActor)
             LegacyDisplayKey = FName(*N.NodeActor->GetResourceName().ToString());
     }
 
+    const FName VisualClassKey = ResClass ? ResClass->GetFName() : Cluster.ResourceName;
     FResourceVisual Visual = ResourceVisuals->GetResourceVisual(
-        Cluster.ResourceName, ResClass, Config.bUseIcons, LegacyDisplayKey);
+        VisualClassKey, ResClass, Config.bUseIcons, LegacyDisplayKey);
     FStampPreset Icons;
     const bool bIsFluid = ResClass
         ? (UFGItemDescriptor::GetForm(ResClass) == EResourceForm::RF_LIQUID
@@ -53,7 +91,7 @@ bool RNM_MapMarkerService::CreateOrUpdateClusterMarker(
     Marker.IconID = Visual.IconID;
     Marker.Scale = Cluster.GetMarkerScale();
     Marker.Name = BuildClusterMarkerName(Cluster);
-    Marker.CategoryName = BuildCategoryName(bIsFluid);
+    Marker.CategoryName = BuildCategoryName(bIsFluid, VisualClassKey);
     Marker.CompassViewDistance = ParseCompassViewDistance(Config.CompassViewDistance);
 
     switch (Cluster.DominantPurity)
@@ -113,18 +151,18 @@ FString RNM_MapMarkerService::BuildClusterMarkerName(const FResourceNodeCluster&
     FString PurityStr;
 
     if (PureCount > 0)
-        PurityStr += FString::Printf(TEXT("%d Pure"), PureCount);
+        PurityStr += FormatLocalizedPurityCount(PureCount, RP_Pure);
 
     if (NormalCount > 0)
     {
         if (!PurityStr.IsEmpty()) PurityStr += TEXT(", ");
-        PurityStr += FString::Printf(TEXT("%d Normal"), NormalCount);
+        PurityStr += FormatLocalizedPurityCount(NormalCount, RP_Normal);
     }
 
     if (ImpureCount > 0)
     {
         if (!PurityStr.IsEmpty()) PurityStr += TEXT(", ");
-        PurityStr += FString::Printf(TEXT("%d Impure"), ImpureCount);
+        PurityStr += FormatLocalizedPurityCount(ImpureCount, RP_Inpure);
     }
 
     FString ResourceLabel;
@@ -148,9 +186,42 @@ bool RNM_MapMarkerService::IsRNMMapMarkerCategory(const FString& Category)
         || Category.StartsWith(TEXT("RNM::Ore#")) || Category.StartsWith(TEXT("RNM::Fluid#"));
 }
 
+FString RNM_MapMarkerService::GetRNMCategoryBase(const FString& Category)
+{
+    const int32 HashIdx = Category.Find(TEXT("#"));
+    return HashIdx == INDEX_NONE ? Category : Category.Left(HashIdx);
+}
+
+bool RNM_MapMarkerService::CategoryMatchesRNMFilter(
+    const FString& FilterCategory,
+    const FString& MarkerCategory)
+{
+    if (FilterCategory == MarkerCategory)
+        return true;
+
+    if (GetRNMCategoryBase(FilterCategory) != GetRNMCategoryBase(MarkerCategory))
+        return false;
+
+    // Legacy RNM::Ore / RNM::Fluid filters include stable RNM::Ore#Desc_* markers.
+    if (!FilterCategory.Contains(TEXT("#")))
+        return true;
+
+    FName FilterClassId;
+    FName MarkerClassId;
+    const bool bFilterHasClassId = TryParseClassIdFromCategory(FilterCategory, FilterClassId);
+    const bool bMarkerHasClassId = TryParseClassIdFromCategory(MarkerCategory, MarkerClassId);
+    if (bFilterHasClassId && bMarkerHasClassId)
+        return FilterClassId == MarkerClassId;
+
+    return !bFilterHasClassId || !bMarkerHasClassId;
+}
+
 bool RNM_MapMarkerService::TryParseClassIdFromCategory(const FString& Category, FName& OutClassFName)
 {
     OutClassFName = NAME_None;
+    if (IsLegacyRNMCategoryWithoutClassId(Category))
+        return false;
+
     const int32 HashIdx = Category.Find(TEXT("#"));
     if (HashIdx == INDEX_NONE) return false;
 
@@ -178,9 +249,12 @@ bool RNM_MapMarkerService::TryParseClassIdFromMarkerName(const FString& MarkerNa
     return true;
 }
 
-FString RNM_MapMarkerService::BuildCategoryName(const bool bIsFluid)
+FString RNM_MapMarkerService::BuildCategoryName(const bool bIsFluid, const FName StableClassId)
 {
-    return bIsFluid ? TEXT("RNM::Fluid") : TEXT("RNM::Ore");
+    const FString Base = bIsFluid ? TEXT("RNM::Fluid") : TEXT("RNM::Ore");
+    if (StableClassId != NAME_None)
+        return FString::Printf(TEXT("%s#%s"), *Base, *StableClassId.ToString());
+    return Base;
 }
 
 ECompassViewDistance RNM_MapMarkerService::ParseCompassViewDistance(int32 Value)

--- a/Source/ResourceNodeMarker/Private/RNM_MapMarkerService.cpp
+++ b/Source/ResourceNodeMarker/Private/RNM_MapMarkerService.cpp
@@ -12,28 +12,48 @@ bool IsLegacyRNMCategoryWithoutClassId(const FString& Category)
     return Category == TEXT("RNM::Ore") || Category == TEXT("RNM::Fluid");
 }
 
-FString FormatLocalizedPurityCount(const int32 Count, const EResourcePurity Purity)
+FString GetPurityDisplayLabel(const FResourceNodeCluster& Cluster, const EResourcePurity Purity)
 {
-    if (Count <= 0) return FString();
+    for (const FResourceNodeInfo& Node : Cluster.Nodes)
+    {
+        if (!Node.NodeActor || Node.Purity != Purity)
+            continue;
 
-    FString Label;
+        const FText GameLabel = Node.NodeActor->GetResoucePurityText();
+        if (!GameLabel.IsEmpty())
+            return GameLabel.ToString();
+        break;
+    }
+
     if (const UEnum* PurityEnum = StaticEnum<EResourcePurity>())
     {
         const int64 EnumValue = static_cast<int64>(Purity);
         if (PurityEnum->IsValidEnumValue(EnumValue))
-            Label = PurityEnum->GetDisplayNameTextByValue(EnumValue).ToString();
-    }
-
-    if (Label.IsEmpty())
-    {
-        switch (Purity)
         {
-        case RP_Pure:   Label = TEXT("Pure"); break;
-        case RP_Normal: Label = TEXT("Normal"); break;
-        case RP_Inpure: Label = TEXT("Impure"); break;
-        default:        return FString();
+            const FText EnumLabel = PurityEnum->GetDisplayNameTextByValue(EnumValue);
+            if (!EnumLabel.IsEmpty())
+                return EnumLabel.ToString();
         }
     }
+
+    switch (Purity)
+    {
+    case RP_Pure:   return TEXT("Pure");
+    case RP_Normal: return TEXT("Normal");
+    case RP_Inpure: return TEXT("Impure");
+    default:        return FString();
+    }
+}
+
+FString FormatPurityCountSegment(
+    const FResourceNodeCluster& Cluster,
+    const int32 Count,
+    const EResourcePurity Purity)
+{
+    if (Count <= 0) return FString();
+
+    const FString Label = GetPurityDisplayLabel(Cluster, Purity);
+    if (Label.IsEmpty()) return FString();
 
     return FString::Printf(TEXT("%d %s"), Count, *Label);
 }
@@ -74,6 +94,7 @@ bool RNM_MapMarkerService::CreateOrUpdateClusterMarker(
             LegacyDisplayKey = FName(*N.NodeActor->GetResourceName().ToString());
     }
 
+    // Cluster.ResourceName is descriptor UClass FName (Desc_*_C), not localized display text.
     const FName VisualClassKey = ResClass ? ResClass->GetFName() : Cluster.ResourceName;
     FResourceVisual Visual = ResourceVisuals->GetResourceVisual(
         VisualClassKey, ResClass, Config.bUseIcons, LegacyDisplayKey);
@@ -151,18 +172,18 @@ FString RNM_MapMarkerService::BuildClusterMarkerName(const FResourceNodeCluster&
     FString PurityStr;
 
     if (PureCount > 0)
-        PurityStr += FormatLocalizedPurityCount(PureCount, RP_Pure);
+        PurityStr += FormatPurityCountSegment(Cluster, PureCount, RP_Pure);
 
     if (NormalCount > 0)
     {
         if (!PurityStr.IsEmpty()) PurityStr += TEXT(", ");
-        PurityStr += FormatLocalizedPurityCount(NormalCount, RP_Normal);
+        PurityStr += FormatPurityCountSegment(Cluster, NormalCount, RP_Normal);
     }
 
     if (ImpureCount > 0)
     {
         if (!PurityStr.IsEmpty()) PurityStr += TEXT(", ");
-        PurityStr += FormatLocalizedPurityCount(ImpureCount, RP_Inpure);
+        PurityStr += FormatPurityCountSegment(Cluster, ImpureCount, RP_Inpure);
     }
 
     FString ResourceLabel;
@@ -177,6 +198,9 @@ FString RNM_MapMarkerService::BuildClusterMarkerName(const FResourceNodeCluster&
     if (ResourceLabel.IsEmpty())
         ResourceLabel = Cluster.ResourceName.ToString();
 
+    if (PurityStr.IsEmpty())
+        return ResourceLabel;
+
     return FString::Printf(TEXT("%s (%s)"), *ResourceLabel, *PurityStr);
 }
 
@@ -184,36 +208,6 @@ bool RNM_MapMarkerService::IsRNMMapMarkerCategory(const FString& Category)
 {
     return Category == TEXT("RNM::Ore") || Category == TEXT("RNM::Fluid")
         || Category.StartsWith(TEXT("RNM::Ore#")) || Category.StartsWith(TEXT("RNM::Fluid#"));
-}
-
-FString RNM_MapMarkerService::GetRNMCategoryBase(const FString& Category)
-{
-    const int32 HashIdx = Category.Find(TEXT("#"));
-    return HashIdx == INDEX_NONE ? Category : Category.Left(HashIdx);
-}
-
-bool RNM_MapMarkerService::CategoryMatchesRNMFilter(
-    const FString& FilterCategory,
-    const FString& MarkerCategory)
-{
-    if (FilterCategory == MarkerCategory)
-        return true;
-
-    if (GetRNMCategoryBase(FilterCategory) != GetRNMCategoryBase(MarkerCategory))
-        return false;
-
-    // Legacy RNM::Ore / RNM::Fluid filters include stable RNM::Ore#Desc_* markers.
-    if (!FilterCategory.Contains(TEXT("#")))
-        return true;
-
-    FName FilterClassId;
-    FName MarkerClassId;
-    const bool bFilterHasClassId = TryParseClassIdFromCategory(FilterCategory, FilterClassId);
-    const bool bMarkerHasClassId = TryParseClassIdFromCategory(MarkerCategory, MarkerClassId);
-    if (bFilterHasClassId && bMarkerHasClassId)
-        return FilterClassId == MarkerClassId;
-
-    return !bFilterHasClassId || !bMarkerHasClassId;
 }
 
 bool RNM_MapMarkerService::TryParseClassIdFromCategory(const FString& Category, FName& OutClassFName)

--- a/Source/ResourceNodeMarker/Private/RNM_ResourceVisuals.cpp
+++ b/Source/ResourceNodeMarker/Private/RNM_ResourceVisuals.cpp
@@ -36,7 +36,7 @@ namespace InGameIcon
 
 struct FResourceCatalogEntry
 {
-    /** Matched via Contains on UClass name; longest match wins (see FindResourceCatalogEntry). */
+    /** Matched on stripped descriptor UClass name; longest match wins (see FindResourceCatalogEntry). */
     const TCHAR* ClassPattern;
     const TCHAR* Hex;
     bool bLiquid;
@@ -369,7 +369,15 @@ FResourceVisual URNM_ResourceVisuals::GetResourceVisual(
 
     const bool bHasCatalogColors = ApplyCatalogColors(Default, ClassNameForPattern);
     if (!bHasCatalogColors)
+    {
+        const FLinearColor NeutralBase(0.55f, 0.55f, 0.55f);
+        GeneratePurityShades(
+            NeutralBase,
+            Default.PureColor,
+            Default.NormalColor,
+            Default.ImpureColor);
         LogUnknownVisualOnce(ResourceClassFName);
+    }
     return Default;
 }
 

--- a/Source/ResourceNodeMarker/Private/RNM_ResourceVisuals.cpp
+++ b/Source/ResourceNodeMarker/Private/RNM_ResourceVisuals.cpp
@@ -3,8 +3,6 @@
 #include "FGItemDescriptor.h"
 #include "FGResourceDescriptor.h"
 
-#include <initializer_list>
-
 namespace
 {
 const FName TryStripBlueprintC(const FName& N)
@@ -21,7 +19,131 @@ void AppendUniqueKey(TArray<FName>& Keys, const FName& N)
         Keys.Add(N);
 }
 
-/** Stock stamps when bUseIcons is false: rock for solids, fluid/drop for liquids/gases. */
+/** In-game map icon ids (FIconsPreset). */
+namespace InGameIcon
+{
+    constexpr int Copper = 198;
+    constexpr int Iron = 193;
+    constexpr int Limestone = 204;
+    constexpr int Caterium = 200;
+    constexpr int Coal = 205;
+    constexpr int Sulfur = 203;
+    constexpr int Bauxite = 199;
+    constexpr int Quartz = 206;
+    constexpr int Uranium = 201;
+    constexpr int Sam = 280;
+}
+
+struct FResourceCatalogEntry
+{
+    /** Matched via Contains on UClass name; longest match wins (see FindResourceCatalogEntry). */
+    const TCHAR* ClassPattern;
+    const TCHAR* Hex;
+    bool bLiquid;
+    int32 IconId;
+    const TCHAR* const* MapKeys;
+    int32 MapKeyCount;
+};
+
+static const TCHAR* CopperMapKeys[] = {
+    TEXT("Copper Ore"), TEXT("Desc_OreCopper_C"), TEXT("Desc_OreCopper"), TEXT("BP_OreCopper_C") };
+static const TCHAR* IronMapKeys[] = {
+    TEXT("Iron Ore"), TEXT("Desc_OreIron_C"), TEXT("Desc_OreIron"), TEXT("BP_OreIron_C") };
+static const TCHAR* LimestoneMapKeys[] = {
+    TEXT("Limestone"), TEXT("Desc_Stone_C"), TEXT("Desc_Stone"), TEXT("Desc_Limestone_C"), TEXT("BP_Stone_C") };
+static const TCHAR* CateriumMapKeys[] = {
+    TEXT("Caterium Ore"), TEXT("Desc_OreCaterium_C"), TEXT("Desc_OreCaterium"), TEXT("BP_OreCaterium_C") };
+static const TCHAR* CoalMapKeys[] = {
+    TEXT("Coal"), TEXT("Desc_OreCoal_C"), TEXT("Desc_OreCoal"), TEXT("BP_OreCoal_C") };
+static const TCHAR* SulfurMapKeys[] = {
+    TEXT("Sulfur"), TEXT("Desc_OreSulfur_C"), TEXT("Desc_OreSulfur"), TEXT("BP_OreSulfur_C") };
+static const TCHAR* BauxiteMapKeys[] = {
+    TEXT("Bauxite"), TEXT("Desc_OreBauxite_C"), TEXT("Desc_OreBauxite"), TEXT("BP_OreBauxite_C") };
+static const TCHAR* QuartzMapKeys[] = {
+    TEXT("Raw Quartz"), TEXT("Desc_OreQuartz_C"), TEXT("Desc_OreQuartz"), TEXT("Desc_Crystal_C"), TEXT("BP_OreQuartz_C") };
+static const TCHAR* UraniumMapKeys[] = {
+    TEXT("Uranium"), TEXT("Desc_OreUranium_C"), TEXT("Desc_OreUranium"), TEXT("BP_OreUranium_C") };
+static const TCHAR* SamMapKeys[] = {
+    TEXT("SAM"), TEXT("Desc_SAM_C"), TEXT("Desc_SAM"), TEXT("Desc_OreSAM_C"), TEXT("BP_SAM_C") };
+static const TCHAR* WaterMapKeys[] = {
+    TEXT("Water"), TEXT("Desc_Water_C"), TEXT("Desc_Water"), TEXT("BP_Water_C") };
+static const TCHAR* OilMapKeys[] = {
+    TEXT("Crude Oil"), TEXT("Desc_LiquidOil_C"), TEXT("Desc_LiquidOil"), TEXT("BP_LiquidOil_C") };
+static const TCHAR* NitrogenMapKeys[] = {
+    TEXT("Nitrogen Gas"), TEXT("Desc_LiquidNitrogen_C"), TEXT("Desc_LiquidNitrogen"), TEXT("BP_LiquidNitrogen_C") };
+static const TCHAR* GeyserMapKeys[] = {
+    TEXT("Geyser"), TEXT("Desc_WaterGeyser_C"), TEXT("Desc_WaterGeyser"), TEXT("BP_WaterGeyser_C") };
+
+/** Single source of truth for hex colors, icon ids, and ResourceVisualMap keys. */
+static const FResourceCatalogEntry ResourceCatalog[] = {
+    { TEXT("Desc_WaterGeyser"), TEXT("00FAB3"), true, 0, GeyserMapKeys, UE_ARRAY_COUNT(GeyserMapKeys) },
+    { TEXT("Desc_LiquidNitrogen"), TEXT("ADADAD"), true, 0, NitrogenMapKeys, UE_ARRAY_COUNT(NitrogenMapKeys) },
+    { TEXT("Desc_LiquidOil"), TEXT("1F1F1F"), true, 0, OilMapKeys, UE_ARRAY_COUNT(OilMapKeys) },
+    { TEXT("Desc_OreCaterium"), TEXT("FFCB00"), false, InGameIcon::Caterium, CateriumMapKeys, UE_ARRAY_COUNT(CateriumMapKeys) },
+    { TEXT("Desc_OreCopper"), TEXT("CF4100"), false, InGameIcon::Copper, CopperMapKeys, UE_ARRAY_COUNT(CopperMapKeys) },
+    { TEXT("Desc_OreBauxite"), TEXT("FFB65E"), false, InGameIcon::Bauxite, BauxiteMapKeys, UE_ARRAY_COUNT(BauxiteMapKeys) },
+    { TEXT("Desc_OreUranium"), TEXT("85FF2E"), false, InGameIcon::Uranium, UraniumMapKeys, UE_ARRAY_COUNT(UraniumMapKeys) },
+    { TEXT("Desc_OreQuartz"), TEXT("FED4FF"), false, InGameIcon::Quartz, QuartzMapKeys, UE_ARRAY_COUNT(QuartzMapKeys) },
+    { TEXT("Desc_OreSulfur"), TEXT("E6E615"), false, InGameIcon::Sulfur, SulfurMapKeys, UE_ARRAY_COUNT(SulfurMapKeys) },
+    { TEXT("Desc_OreIron"), TEXT("93959E"), false, InGameIcon::Iron, IronMapKeys, UE_ARRAY_COUNT(IronMapKeys) },
+    { TEXT("Desc_Stone"), TEXT("D1B97B"), false, InGameIcon::Limestone, LimestoneMapKeys, UE_ARRAY_COUNT(LimestoneMapKeys) },
+    { TEXT("Desc_OreCoal"), TEXT("403B3B"), false, InGameIcon::Coal, CoalMapKeys, UE_ARRAY_COUNT(CoalMapKeys) },
+    { TEXT("Desc_OreSAM"), TEXT("A332C9"), false, InGameIcon::Sam, SamMapKeys, UE_ARRAY_COUNT(SamMapKeys) },
+    { TEXT("Desc_SAM"), TEXT("A332C9"), false, InGameIcon::Sam, SamMapKeys, UE_ARRAY_COUNT(SamMapKeys) },
+    { TEXT("Desc_Water"), TEXT("17E3CE"), true, 0, WaterMapKeys, UE_ARRAY_COUNT(WaterMapKeys) },
+    { TEXT("Desc_Crystal"), TEXT("FED4FF"), false, InGameIcon::Quartz, QuartzMapKeys, UE_ARRAY_COUNT(QuartzMapKeys) },
+};
+
+FString NormalizeDescriptorClassName(FString ClassName)
+{
+    if (ClassName.EndsWith(TEXT("_C"), ESearchCase::CaseSensitive) && ClassName.Len() > 2)
+        return ClassName.Left(ClassName.Len() - 2);
+    return ClassName;
+}
+
+bool ClassNameMatchesCatalogPattern(const FString& NormalizedClassName, const TCHAR* Pattern)
+{
+    const FString PatternStr(Pattern);
+    if (NormalizedClassName == PatternStr)
+        return true;
+
+    if (!NormalizedClassName.StartsWith(PatternStr))
+        return false;
+
+    if (NormalizedClassName.Len() == PatternStr.Len())
+        return true;
+
+    const TCHAR Next = NormalizedClassName[PatternStr.Len()];
+    return Next == TEXT('_');
+}
+
+const FResourceCatalogEntry* FindResourceCatalogEntry(const FString& ClassName)
+{
+    const FString Normalized = NormalizeDescriptorClassName(ClassName);
+    const FResourceCatalogEntry* Best = nullptr;
+    int32 BestPatternLen = 0;
+
+    for (const FResourceCatalogEntry& Entry : ResourceCatalog)
+    {
+        if (!ClassNameMatchesCatalogPattern(Normalized, Entry.ClassPattern))
+            continue;
+
+        const int32 PatternLen = FCString::Strlen(Entry.ClassPattern);
+        if (PatternLen > BestPatternLen)
+        {
+            BestPatternLen = PatternLen;
+            Best = &Entry;
+        }
+    }
+
+    return Best;
+}
+
+FLinearColor ColorFromHex(const FString& Hex)
+{
+    return FLinearColor::FromSRGBColor(FColor::FromHex(Hex));
+}
+
 int32 GetStampIconIdForOreOrFluid(TSubclassOf<UFGResourceDescriptor> ResClass)
 {
     FStampPreset Sp;
@@ -34,7 +156,6 @@ int32 GetStampIconIdForOreOrFluid(TSubclassOf<UFGResourceDescriptor> ResClass)
     return Sp.Rock;
 }
 
-/** When bUseIcons is true and visuals miss: map descriptor class names to in-game map icon IDs (FIconsPreset). */
 int32 ResolveInGameIconIdFromResourceClass(TSubclassOf<UFGResourceDescriptor> ResClass)
 {
     FStampPreset Sp;
@@ -44,113 +165,81 @@ int32 ResolveInGameIconIdFromResourceClass(TSubclassOf<UFGResourceDescriptor> Re
     if (Form == EResourceForm::RF_LIQUID || Form == EResourceForm::RF_GAS)
         return Sp.Fluids;
 
-    const FString S = ResClass->GetName();
-    FIconsPreset Ip;
-    if (S.Contains(TEXT("Iron"))) return Ip.Iron;
-    if (S.Contains(TEXT("Copper"))) return Ip.Copper;
-    if (S.Contains(TEXT("Limestone"))) return Ip.Limestone;
-    if (S.Contains(TEXT("Stone"))) return Ip.Limestone;
-    if (S.Contains(TEXT("Coal"))) return Ip.Coal;
-    if (S.Contains(TEXT("Sulfur"))) return Ip.Sulfur;
-    if (S.Contains(TEXT("Bauxite"))) return Ip.Bauxite;
-    if (S.Contains(TEXT("Quartz"))) return Ip.Quartz;
-    if (S.Contains(TEXT("Uranium"))) return Ip.Uranium;
-    if (S.Contains(TEXT("Caterium"))) return Ip.Caterium;
-    if (S.Contains(TEXT("Sam"))) return Ip.Sam;
+    if (const FResourceCatalogEntry* Entry = FindResourceCatalogEntry(ResClass->GetName()))
+        return Entry->IconId != 0 ? Entry->IconId : Sp.Rock;
 
     return Sp.Rock;
+}
+
+FResourceVisual BuildVisualFromCatalogEntry(
+    const FResourceCatalogEntry& Entry,
+    const bool bUseIcons,
+    TSubclassOf<UFGResourceDescriptor> ResClass)
+{
+    FResourceVisual Visual;
+    FStampPreset Stamp;
+    Visual.IconID = Entry.bLiquid ? Stamp.Fluids : Stamp.Rock;
+    URNM_ResourceVisuals::GeneratePurityShades(
+        ColorFromHex(Entry.Hex),
+        Visual.PureColor,
+        Visual.NormalColor,
+        Visual.ImpureColor);
+
+    if (bUseIcons)
+        Visual.IconID = ResClass ? ResolveInGameIconIdFromResourceClass(ResClass)
+            : (Entry.IconId != 0 ? Entry.IconId : Stamp.Rock);
+
+    return Visual;
+}
+
+bool ApplyCatalogColors(FResourceVisual& Visual, const FString& ClassName)
+{
+    if (const FResourceCatalogEntry* Entry = FindResourceCatalogEntry(ClassName))
+    {
+        const FResourceVisual Colors = BuildVisualFromCatalogEntry(
+            *Entry, /*bUseIcons=*/false, nullptr);
+        Visual.PureColor = Colors.PureColor;
+        Visual.NormalColor = Colors.NormalColor;
+        Visual.ImpureColor = Colors.ImpureColor;
+        return true;
+    }
+    return false;
+}
+
+void LogUnknownVisualOnce(const FName& ResourceClassFName)
+{
+    static TSet<FName> Warned;
+    if (Warned.Contains(ResourceClassFName))
+        return;
+
+    Warned.Add(ResourceClassFName);
+    UE_LOG(LogResourceNodeMarker, Warning,
+        TEXT("RNM_ResourceVisuals: No visual found for class keys around '%s', using fallback"),
+        *ResourceClassFName.ToString());
 }
 }
 
 URNM_ResourceVisuals::URNM_ResourceVisuals()
 {
     FStampPreset Stamp;
-    FIconsPreset Icons;
 
-    auto MakeColor = [](const FString& Hex)
-    {
-        return FLinearColor::FromSRGBColor(FColor::FromHex(Hex));
-    };
-
-    /** Same purity shades + stamp icon for every lookup key (English display + UClass FNames). */
-    auto AddResourceGroup = [&](const std::initializer_list<const TCHAR*> Names, const FString& BaseHex,
-                                const bool bLiquid)
+    for (const FResourceCatalogEntry& Entry : ResourceCatalog)
     {
         FResourceVisual Visual;
-        Visual.IconID = bLiquid ? Stamp.Fluids : Stamp.Rock;
+        Visual.IconID = Entry.bLiquid ? Stamp.Fluids : Stamp.Rock;
         GeneratePurityShades(
-            MakeColor(BaseHex),
+            ColorFromHex(Entry.Hex),
             Visual.PureColor,
             Visual.NormalColor,
             Visual.ImpureColor);
-        for (const TCHAR* Name : Names)
-            ResourceVisualMap.Add(FName(Name), Visual);
-    };
 
-    // Solid ores: legacy English keys (main) plus descriptor class FNames for language-independent scans.
-    AddResourceGroup(
-        {TEXT("Copper Ore"), TEXT("Desc_OreCopper_C"), TEXT("Desc_OreCopper"), TEXT("BP_OreCopper_C")},
-        TEXT("CF4100"), false);
-    AddResourceGroup(
-        {TEXT("Iron Ore"), TEXT("Desc_OreIron_C"), TEXT("Desc_OreIron"), TEXT("BP_OreIron_C")},
-        TEXT("93959E"), false);
-    AddResourceGroup(
-        {TEXT("Limestone"), TEXT("Desc_Stone_C"), TEXT("Desc_Stone"), TEXT("Desc_Limestone_C"), TEXT("BP_Stone_C")},
-        TEXT("D1B97B"), false);
-    AddResourceGroup(
-        {TEXT("Caterium Ore"), TEXT("Desc_OreCaterium_C"), TEXT("Desc_OreCaterium"), TEXT("BP_OreCaterium_C")},
-        TEXT("FFCB00"), false);
-    AddResourceGroup(
-        {TEXT("Coal"), TEXT("Desc_OreCoal_C"), TEXT("Desc_OreCoal"), TEXT("BP_OreCoal_C")},
-        TEXT("403B3B"), false);
-    AddResourceGroup(
-        {TEXT("Sulfur"), TEXT("Desc_OreSulfur_C"), TEXT("Desc_OreSulfur"), TEXT("BP_OreSulfur_C")},
-        TEXT("E6E615"), false);
-    AddResourceGroup(
-        {TEXT("Bauxite"), TEXT("Desc_OreBauxite_C"), TEXT("Desc_OreBauxite"), TEXT("BP_OreBauxite_C")},
-        TEXT("FFB65E"), false);
-    AddResourceGroup(
-        {TEXT("Raw Quartz"), TEXT("Desc_OreQuartz_C"), TEXT("Desc_OreQuartz"), TEXT("Desc_Crystal_C"), TEXT("BP_OreQuartz_C")},
-        TEXT("FED4FF"), false);
-    AddResourceGroup(
-        {TEXT("Uranium"), TEXT("Desc_OreUranium_C"), TEXT("Desc_OreUranium"), TEXT("BP_OreUranium_C")},
-        TEXT("85FF2E"), false);
-    AddResourceGroup(
-        {TEXT("SAM"), TEXT("Desc_SAM_C"), TEXT("Desc_SAM"), TEXT("Desc_OreSAM_C"), TEXT("BP_SAM_C")},
-        TEXT("A332C9"), false);
-
-    AddResourceGroup(
-        {TEXT("Water"), TEXT("Desc_Water_C"), TEXT("Desc_Water"), TEXT("BP_Water_C")},
-        TEXT("17E3CE"), true);
-    AddResourceGroup(
-        {TEXT("Crude Oil"), TEXT("Desc_LiquidOil_C"), TEXT("Desc_LiquidOil"), TEXT("BP_LiquidOil_C")},
-        TEXT("1F1F1F"), true);
-    AddResourceGroup(
-        {TEXT("Nitrogen Gas"), TEXT("Desc_LiquidNitrogen_C"), TEXT("Desc_LiquidNitrogen"), TEXT("BP_LiquidNitrogen_C")},
-        TEXT("ADADAD"), true);
-    AddResourceGroup(
-        {TEXT("Geyser"), TEXT("Desc_WaterGeyser_C"), TEXT("Desc_WaterGeyser"), TEXT("BP_WaterGeyser_C")},
-        TEXT("00FAB3"), true);
-
-    auto AddIconPair = [&](const std::initializer_list<const TCHAR*> Names, const int32 IconId)
-    {
-        for (const TCHAR* N : Names)
-            IconMap.Add(FName(N), IconId);
-    };
-
-    AddIconPair({TEXT("Copper Ore"), TEXT("Desc_OreCopper_C"), TEXT("Desc_OreCopper"), TEXT("BP_OreCopper_C")}, Icons.Copper);
-    AddIconPair({TEXT("Iron Ore"), TEXT("Desc_OreIron_C"), TEXT("Desc_OreIron"), TEXT("BP_OreIron_C")}, Icons.Iron);
-    AddIconPair({TEXT("Limestone"), TEXT("Desc_Stone_C"), TEXT("Desc_Stone"), TEXT("Desc_Limestone_C"), TEXT("BP_Stone_C")},
-        Icons.Limestone);
-    AddIconPair({TEXT("Caterium Ore"), TEXT("Desc_OreCaterium_C"), TEXT("Desc_OreCaterium"), TEXT("BP_OreCaterium_C")},
-        Icons.Caterium);
-    AddIconPair({TEXT("Coal"), TEXT("Desc_OreCoal_C"), TEXT("Desc_OreCoal"), TEXT("BP_OreCoal_C")}, Icons.Coal);
-    AddIconPair({TEXT("Sulfur"), TEXT("Desc_OreSulfur_C"), TEXT("Desc_OreSulfur"), TEXT("BP_OreSulfur_C")}, Icons.Sulfur);
-    AddIconPair({TEXT("Bauxite"), TEXT("Desc_OreBauxite_C"), TEXT("Desc_OreBauxite"), TEXT("BP_OreBauxite_C")}, Icons.Bauxite);
-    AddIconPair({TEXT("Raw Quartz"), TEXT("Desc_OreQuartz_C"), TEXT("Desc_OreQuartz"), TEXT("Desc_Crystal_C"), TEXT("BP_OreQuartz_C")},
-        Icons.Quartz);
-    AddIconPair({TEXT("Uranium"), TEXT("Desc_OreUranium_C"), TEXT("Desc_OreUranium"), TEXT("BP_OreUranium_C")}, Icons.Uranium);
-    AddIconPair({TEXT("SAM"), TEXT("Desc_SAM_C"), TEXT("Desc_SAM"), TEXT("Desc_OreSAM_C"), TEXT("BP_SAM_C")}, Icons.Sam);
+        for (int32 i = 0; i < Entry.MapKeyCount; ++i)
+        {
+            ResourceVisualMap.Add(FName(Entry.MapKeys[i]), Visual);
+            if (Entry.IconId != 0)
+                IconMap.Add(FName(Entry.MapKeys[i]), Entry.IconId);
+        }
+    }
 }
 
 FResourceVisual URNM_ResourceVisuals::GetResourceVisual(const FName& ResourceName, const bool bUseIcons) const
@@ -164,21 +253,6 @@ FResourceVisual URNM_ResourceVisuals::GetResourceVisual(
     const bool bUseIcons,
     const FName OptionalLegacyDisplayKey) const
 {
-    TArray<FName> Keys;
-    AppendUniqueKey(Keys, ResourceClassFName);
-    AppendUniqueKey(Keys, TryStripBlueprintC(ResourceClassFName));
-    AppendUniqueKey(Keys, OptionalLegacyDisplayKey);
-
-    if (ResClass)
-    {
-        AppendUniqueKey(Keys, ResClass->GetFName());
-        AppendUniqueKey(Keys, TryStripBlueprintC(ResClass->GetFName()));
-        // Legacy map keys: English (or current locale) display name from the item descriptor
-        const FText ItemName = UFGItemDescriptor::GetItemName(ResClass);
-        if (!ItemName.IsEmpty())
-            AppendUniqueKey(Keys, FName(*ItemName.ToString()));
-    }
-
     FStampPreset Preset;
 
     auto FinalizeIconId = [&](FResourceVisual& R)
@@ -193,23 +267,28 @@ FResourceVisual URNM_ResourceVisuals::GetResourceVisual(
         R.IconID = ResolveInGameIconIdFromResourceClass(ResClass);
     };
 
-    for (const FName& Key : Keys)
+    auto TryMapKeys = [&](const TArray<FName>& Keys, const bool bIconMapOnly) -> TOptional<FResourceVisual>
     {
-        if (const FResourceVisual* Found = ResourceVisualMap.Find(Key))
+        if (!bIconMapOnly)
         {
-            FResourceVisual R = *Found;
-            if (bUseIcons)
+            for (const FName& Key : Keys)
             {
-                if (const int32* Icon = IconMap.Find(Key))
-                    R.IconID = *Icon;
+                if (const FResourceVisual* Found = ResourceVisualMap.Find(Key))
+                {
+                    FResourceVisual R = *Found;
+                    if (bUseIcons)
+                    {
+                        if (const int32* Icon = IconMap.Find(Key))
+                            R.IconID = *Icon;
+                    }
+                    FinalizeIconId(R);
+                    return R;
+                }
             }
-            FinalizeIconId(R);
-            return R;
         }
-    }
 
-    if (bUseIcons)
-    {
+        if (!bUseIcons) return NullOpt;
+
         for (const FName& Key : Keys)
         {
             if (const int32* Icon = IconMap.Find(Key))
@@ -220,6 +299,65 @@ FResourceVisual URNM_ResourceVisuals::GetResourceVisual(
                 return R;
             }
         }
+        return NullOpt;
+    };
+
+    FString ClassNameForPattern = ResourceClassFName.ToString();
+    if (ResClass)
+        ClassNameForPattern = ResClass->GetName();
+
+    // Phase 1: UClass FNames only — stable across game language.
+    TArray<FName> ClassKeys;
+    AppendUniqueKey(ClassKeys, ResourceClassFName);
+    AppendUniqueKey(ClassKeys, TryStripBlueprintC(ResourceClassFName));
+    if (ResClass)
+    {
+        AppendUniqueKey(ClassKeys, ResClass->GetFName());
+        AppendUniqueKey(ClassKeys, TryStripBlueprintC(ResClass->GetFName()));
+    }
+
+    if (TOptional<FResourceVisual> Found = TryMapKeys(ClassKeys, /*bIconMapOnly=*/false))
+        return Found.GetValue();
+
+    // Phase 2: longest ClassPattern match on descriptor UClass name.
+    if (const FResourceCatalogEntry* Entry = FindResourceCatalogEntry(ClassNameForPattern))
+    {
+        FResourceVisual R = BuildVisualFromCatalogEntry(*Entry, bUseIcons, ResClass);
+        FinalizeIconId(R);
+        return R;
+    }
+
+    // Phase 3: localized / legacy display names (English map keys, current locale GetItemName).
+    TArray<FName> DisplayKeys;
+    AppendUniqueKey(DisplayKeys, OptionalLegacyDisplayKey);
+    if (ResClass)
+    {
+        const FText ItemName = UFGItemDescriptor::GetItemName(ResClass);
+        if (!ItemName.IsEmpty())
+            AppendUniqueKey(DisplayKeys, FName(*ItemName.ToString()));
+    }
+
+    if (TOptional<FResourceVisual> Found = TryMapKeys(DisplayKeys, /*bIconMapOnly=*/false))
+        return Found.GetValue();
+
+    if (bUseIcons)
+    {
+        if (TOptional<FResourceVisual> IconOnly = TryMapKeys(DisplayKeys, /*bIconMapOnly=*/true))
+        {
+            FResourceVisual R = IconOnly.GetValue();
+            const bool bHasCatalogColors = ApplyCatalogColors(R, ClassNameForPattern);
+            if (!bHasCatalogColors)
+            {
+                if (TOptional<FResourceVisual> ClassColors = TryMapKeys(ClassKeys, /*bIconMapOnly=*/false))
+                {
+                    R.PureColor = ClassColors->PureColor;
+                    R.NormalColor = ClassColors->NormalColor;
+                    R.ImpureColor = ClassColors->ImpureColor;
+                }
+            }
+            FinalizeIconId(R);
+            return R;
+        }
     }
 
     FResourceVisual Default;
@@ -229,9 +367,9 @@ FResourceVisual URNM_ResourceVisuals::GetResourceVisual(
     else if (ResClass)
         Default.IconID = ResolveInGameIconIdFromResourceClass(ResClass);
 
-    UE_LOG(LogResourceNodeMarker, Warning,
-        TEXT("RNM_ResourceVisuals: No visual found for keys around '%s', using fallback"),
-        *ResourceClassFName.ToString());
+    const bool bHasCatalogColors = ApplyCatalogColors(Default, ClassNameForPattern);
+    if (!bHasCatalogColors)
+        LogUnknownVisualOnce(ResourceClassFName);
     return Default;
 }
 
@@ -248,13 +386,11 @@ void URNM_ResourceVisuals::GeneratePurityShades(
 
     OutNormal = BaseColor;
 
-    // Pure: more saturated, slightly darker
     OutPure = FLinearColor(H,
         FMath::Clamp(S * 1.4f, 0.0f, 1.0f),
         FMath::Clamp(V * 0.75f, 0.0f, 1.0f),
         1.0f).HSVToLinearRGB();
 
-    // Impure: less saturated, brighter
     OutImpure = FLinearColor(H,
         FMath::Clamp(S * 0.7f, 0.0f, 1.0f),
         FMath::Clamp(V * 1.5f, 0.0f, 1.0f),

--- a/Source/ResourceNodeMarker/Private/RNM_ResourceVisuals.cpp
+++ b/Source/ResourceNodeMarker/Private/RNM_ResourceVisuals.cpp
@@ -206,6 +206,58 @@ bool ApplyCatalogColors(FResourceVisual& Visual, const FString& ClassName)
     return false;
 }
 
+void ApplyNeutralFallbackColors(FResourceVisual& Visual)
+{
+    const FLinearColor NeutralBase(0.55f, 0.55f, 0.55f);
+    URNM_ResourceVisuals::GeneratePurityShades(
+        NeutralBase,
+        Visual.PureColor,
+        Visual.NormalColor,
+        Visual.ImpureColor);
+}
+
+void ApplyFallbackColors(
+    FResourceVisual& Visual,
+    const FString& ClassName,
+    const TArray<FName>& ClassKeys,
+    const TFunctionRef<TOptional<FResourceVisual>(const TArray<FName>&, bool)>& TryMapKeys)
+{
+    if (ApplyCatalogColors(Visual, ClassName))
+        return;
+
+    if (const TOptional<FResourceVisual> ClassColors = TryMapKeys(ClassKeys, /*bIconMapOnly=*/false))
+    {
+        Visual.PureColor = ClassColors->PureColor;
+        Visual.NormalColor = ClassColors->NormalColor;
+        Visual.ImpureColor = ClassColors->ImpureColor;
+        return;
+    }
+
+    ApplyNeutralFallbackColors(Visual);
+}
+
+/** @return false when neutral gray fallback was applied. */
+bool ApplyKnownColorsOrNeutral(
+    FResourceVisual& Visual,
+    const FString& ClassName,
+    const TArray<FName>& ClassKeys,
+    const TFunctionRef<TOptional<FResourceVisual>(const TArray<FName>&, bool)>& TryMapKeys)
+{
+    if (ApplyCatalogColors(Visual, ClassName))
+        return true;
+
+    if (const TOptional<FResourceVisual> ClassColors = TryMapKeys(ClassKeys, /*bIconMapOnly=*/false))
+    {
+        Visual.PureColor = ClassColors->PureColor;
+        Visual.NormalColor = ClassColors->NormalColor;
+        Visual.ImpureColor = ClassColors->ImpureColor;
+        return true;
+    }
+
+    ApplyNeutralFallbackColors(Visual);
+    return false;
+}
+
 void LogUnknownVisualOnce(const FName& ResourceClassFName)
 {
     static TSet<FName> Warned;
@@ -345,16 +397,7 @@ FResourceVisual URNM_ResourceVisuals::GetResourceVisual(
         if (TOptional<FResourceVisual> IconOnly = TryMapKeys(DisplayKeys, /*bIconMapOnly=*/true))
         {
             FResourceVisual R = IconOnly.GetValue();
-            const bool bHasCatalogColors = ApplyCatalogColors(R, ClassNameForPattern);
-            if (!bHasCatalogColors)
-            {
-                if (TOptional<FResourceVisual> ClassColors = TryMapKeys(ClassKeys, /*bIconMapOnly=*/false))
-                {
-                    R.PureColor = ClassColors->PureColor;
-                    R.NormalColor = ClassColors->NormalColor;
-                    R.ImpureColor = ClassColors->ImpureColor;
-                }
-            }
+            ApplyFallbackColors(R, ClassNameForPattern, ClassKeys, TryMapKeys);
             FinalizeIconId(R);
             return R;
         }
@@ -367,17 +410,8 @@ FResourceVisual URNM_ResourceVisuals::GetResourceVisual(
     else if (ResClass)
         Default.IconID = ResolveInGameIconIdFromResourceClass(ResClass);
 
-    const bool bHasCatalogColors = ApplyCatalogColors(Default, ClassNameForPattern);
-    if (!bHasCatalogColors)
-    {
-        const FLinearColor NeutralBase(0.55f, 0.55f, 0.55f);
-        GeneratePurityShades(
-            NeutralBase,
-            Default.PureColor,
-            Default.NormalColor,
-            Default.ImpureColor);
+    if (!ApplyKnownColorsOrNeutral(Default, ClassNameForPattern, ClassKeys, TryMapKeys))
         LogUnknownVisualOnce(ResourceClassFName);
-    }
     return Default;
 }
 

--- a/Source/ResourceNodeMarker/Private/RNM_ResourceVisuals.cpp
+++ b/Source/ResourceNodeMarker/Private/RNM_ResourceVisuals.cpp
@@ -19,7 +19,7 @@ void AppendUniqueKey(TArray<FName>& Keys, const FName& N)
         Keys.Add(N);
 }
 
-/** In-game map icon ids (FIconsPreset). */
+/** In-game map icon ids — must stay in sync with FIconsPreset in RNM_ResourceVisuals.h. */
 namespace InGameIcon
 {
     constexpr int Copper = 198;
@@ -216,24 +216,34 @@ void ApplyNeutralFallbackColors(FResourceVisual& Visual)
         Visual.ImpureColor);
 }
 
-void ApplyFallbackColors(
+bool TryApplyKnownColors(
     FResourceVisual& Visual,
     const FString& ClassName,
     const TArray<FName>& ClassKeys,
     const TFunctionRef<TOptional<FResourceVisual>(const TArray<FName>&, bool)>& TryMapKeys)
 {
     if (ApplyCatalogColors(Visual, ClassName))
-        return;
+        return true;
 
     if (const TOptional<FResourceVisual> ClassColors = TryMapKeys(ClassKeys, /*bIconMapOnly=*/false))
     {
         Visual.PureColor = ClassColors->PureColor;
         Visual.NormalColor = ClassColors->NormalColor;
         Visual.ImpureColor = ClassColors->ImpureColor;
-        return;
+        return true;
     }
 
-    ApplyNeutralFallbackColors(Visual);
+    return false;
+}
+
+void ApplyFallbackColors(
+    FResourceVisual& Visual,
+    const FString& ClassName,
+    const TArray<FName>& ClassKeys,
+    const TFunctionRef<TOptional<FResourceVisual>(const TArray<FName>&, bool)>& TryMapKeys)
+{
+    if (!TryApplyKnownColors(Visual, ClassName, ClassKeys, TryMapKeys))
+        ApplyNeutralFallbackColors(Visual);
 }
 
 /** @return false when neutral gray fallback was applied. */
@@ -243,16 +253,8 @@ bool ApplyKnownColorsOrNeutral(
     const TArray<FName>& ClassKeys,
     const TFunctionRef<TOptional<FResourceVisual>(const TArray<FName>&, bool)>& TryMapKeys)
 {
-    if (ApplyCatalogColors(Visual, ClassName))
+    if (TryApplyKnownColors(Visual, ClassName, ClassKeys, TryMapKeys))
         return true;
-
-    if (const TOptional<FResourceVisual> ClassColors = TryMapKeys(ClassKeys, /*bIconMapOnly=*/false))
-    {
-        Visual.PureColor = ClassColors->PureColor;
-        Visual.NormalColor = ClassColors->NormalColor;
-        Visual.ImpureColor = ClassColors->ImpureColor;
-        return true;
-    }
 
     ApplyNeutralFallbackColors(Visual);
     return false;
@@ -261,7 +263,11 @@ bool ApplyKnownColorsOrNeutral(
 void LogUnknownVisualOnce(const FName& ResourceClassFName)
 {
     static TSet<FName> Warned;
+    static constexpr int32 MaxWarnedEntries = 128;
     if (Warned.Contains(ResourceClassFName))
+        return;
+
+    if (Warned.Num() >= MaxWarnedEntries)
         return;
 
     Warned.Add(ResourceClassFName);

--- a/Source/ResourceNodeMarker/Private/RNM_WorldSubsystem.cpp
+++ b/Source/ResourceNodeMarker/Private/RNM_WorldSubsystem.cpp
@@ -29,7 +29,8 @@ void URNM_WorldSubsystem::InitializeConfig()
     ConfigData = FResourceNodeMarker_ConfigStruct::GetActiveConfig(GetWorld());
     bConfigLoaded = true;
 
-    PlayerProximityThresholdSq = (ConfigData.ProximityRadius * 100.0f) * (ConfigData.ProximityRadius * 100.0f);
+    const float ProximityRadiusCm = FResourceNodeMarker_ConfigStruct::GetProximityRadiusCm(ConfigData);
+    PlayerProximityThresholdSq = ProximityRadiusCm * ProximityRadiusCm;
 
     UE_LOG(LogResourceNodeMarker, Log, TEXT("RNM: Config loaded"));
     UE_LOG(LogResourceNodeMarker, Log, TEXT("RNM: --- Purity Settings ---"));
@@ -47,7 +48,7 @@ void URNM_WorldSubsystem::InitializeConfig()
     UE_LOG(LogResourceNodeMarker, Log, TEXT("RNM: --- Proximity Settings ---"));
     UE_LOG(LogResourceNodeMarker, Log, TEXT("RNM: Proximity Radius: %.0fm (%.0fcm)"),
         ConfigData.ProximityRadius,
-        ConfigData.ProximityRadius * 100.0f);
+        ProximityRadiusCm);
     UE_LOG(LogResourceNodeMarker, Log, TEXT("RNM: --- Extractor Settings ---"));
     UE_LOG(LogResourceNodeMarker, Log, TEXT("RNM: Extractor Marker Behavior: %d (%s)"),
         ConfigData.ExtractorMarkerBehavior,

--- a/Source/ResourceNodeMarker/Public/RNM_ClusterManager.h
+++ b/Source/ResourceNodeMarker/Public/RNM_ClusterManager.h
@@ -15,7 +15,11 @@ class RESOURCENODEMARKER_API URNM_ClusterManager : public UObject
 public:
     /**
      * Initializes the cluster manager with required dependencies.
-     * Must be called before any other method.
+     * Must be called before any other method; resets all discovery state.
+     * @param InResourceNodes - Scanned nodes (owned by URNM_WorldSubsystem).
+     * @param InSpatialGrid - Cell index built from InResourceNodes.
+     * @param InResourceVisuals - Icon and purity color lookup.
+     * @param InConfig - Active mod configuration (radius, clustering, icons).
      */
     void Initialize(
         const TArray<FResourceNodeInfo>& InResourceNodes,
@@ -24,38 +28,48 @@ public:
         const FResourceNodeMarker_ConfigStruct& InConfig);
 
     /**
-     * Reads existing RNM:: markers from the map and rebuilds cluster state from them.
-     * Does not create any new markers.
+     * Rebuilds in-memory cluster state from existing RNM map markers.
+     * Does not create or delete markers; used before a full marker refresh on load.
+     * @param World - The game world (reads markers via AFGMapManager).
      */
     void RebuildClustersFromExistingMarkers(UWorld* World);
 
     /**
-     * Deletes RNM map markers (legacy and RNM::#class-id categories).
+     * Removes every map marker whose CategoryName is RNM-owned.
+     * @param World - The game world.
      */
     void DeleteAllRNMMarkers(UWorld* World);
 
     /**
-     * Creates one map marker per cluster (or one per node when bClusterNodes is false).
-     * Should be called after DeleteAllRNMMarkers.
+     * Creates one map marker per cluster (or one per node when clustering is disabled).
+     * Call after DeleteAllRNMMarkers when replacing all markers on load.
+     * @param World - The game world.
+     * @return Number of markers created successfully.
      */
-    /** @return Number of markers created successfully. */
     int32 CreateAllClusterMarkers(UWorld* World);
 
     /**
-     * Called when the player discovers a new node.
-     * When clustering is enabled: adds to a neighbor cluster or merges; when disabled, always a solo marker.
+     * Handles proximity discovery for a single node index.
+     * Clusters or merges neighbors when enabled; rolls back state if marker create fails.
+     * @param World - The game world.
+     * @param NodeIndex - Index into the scanned ResourceNodes array.
      */
     void OnNodeDiscovered(UWorld* World, int32 NodeIndex);
 
-    /** Returns true if the node at the given index has already been discovered. */
+    /**
+     * Returns whether the node has been discovered (marker placed or extractor handled).
+     * @param NodeIndex - Index into the scanned ResourceNodes array.
+     */
     bool IsNodeDiscovered(int32 NodeIndex) const;
 
     /**
-     * Called when an extractor is placed on a node.
-     * Marks node as discovered, removes it from its cluster,
-     * deletes the cluster marker and recreates it if nodes remain.
+     * Updates cluster state when an extractor is placed on a node.
+     * Removes the node from its cluster and recreates or deletes the cluster marker.
+     * Rolls back the node removal if marker update fails.
+     * @param World - The game world.
+     * @param NodeLocation - World location of the resource node under the extractor.
      */
-     void OnExtractorPlaced(UWorld* World, const FVector& NodeLocation);
+    void OnExtractorPlaced(UWorld* World, const FVector& NodeLocation);
 
 private:
     bool MergeClusters(UWorld* World, int32 TargetIndex, int32 SourceIndex, bool bRemoveSourceMarker = true);

--- a/Source/ResourceNodeMarker/Public/RNM_MapMarkerService.h
+++ b/Source/ResourceNodeMarker/Public/RNM_MapMarkerService.h
@@ -46,21 +46,6 @@ public:
     static bool IsRNMMapMarkerCategory(const FString& Category);
 
     /**
-     * Returns the RNM category prefix before an optional #ClassFName suffix.
-     * @param Category - Full CategoryName from a map marker.
-     * @return RNM::Ore, RNM::Fluid, or the input when not an RNM category.
-     */
-    static FString GetRNMCategoryBase(const FString& Category);
-
-    /**
-     * True when FilterCategory should include MarkerCategory in map filter UI.
-     * Legacy RNM::Ore matches new RNM::Ore#Desc_* markers with the same base.
-     * @param FilterCategory - Selected filter category.
-     * @param MarkerCategory - Marker CategoryName.
-     */
-    static bool CategoryMatchesRNMFilter(const FString& FilterCategory, const FString& MarkerCategory);
-
-    /**
      * Parses a stable resource class id embedded in CategoryName.
      * @param Category - Expected form RNM::Ore#Desc_OreIron_C or RNM::Fluid#Desc_Water_C.
      * @param OutClassFName - UClass FName when parsing succeeds.

--- a/Source/ResourceNodeMarker/Public/RNM_MapMarkerService.h
+++ b/Source/ResourceNodeMarker/Public/RNM_MapMarkerService.h
@@ -7,6 +7,7 @@
 #include "RNM_ResourceVisuals.h"
 #include "ResourceNodeMarker_ConfigStruct.h"
 
+/** Stateless helpers for creating, naming, and identifying RNM map markers. */
 class RNM_MapMarkerService
 {
 public:
@@ -30,22 +31,63 @@ public:
         const FResourceNodeMarker_ConfigStruct& Config,
         FGuid& OutGUID);
 
+    /**
+     * Maps config integer (0–4) to Satisfactory compass view distance.
+     * @param Value - Config CompassViewDistance; invalid values log a warning and default to Mid.
+     * @return Matching ECompassViewDistance for the map marker.
+     */
     static ECompassViewDistance ParseCompassViewDistance(int32 Value);
 
-    /** RNM markers (legacy RNM::Ore / RNM::Fluid or v2 RNM::Ore#ClassFName). */
+    /**
+     * Returns true if Category is an RNM-owned marker category.
+     * Accepts legacy RNM::Ore / RNM::Fluid and stable RNM::Ore#ClassFName forms.
+     * @param Category - FMapMarker::CategoryName from the map manager.
+     */
     static bool IsRNMMapMarkerCategory(const FString& Category);
 
-    /** Legacy: category held RNM::Ore#ClassFName. Still parsed for old saves. */
+    /**
+     * Returns the RNM category prefix before an optional #ClassFName suffix.
+     * @param Category - Full CategoryName from a map marker.
+     * @return RNM::Ore, RNM::Fluid, or the input when not an RNM category.
+     */
+    static FString GetRNMCategoryBase(const FString& Category);
+
+    /**
+     * True when FilterCategory should include MarkerCategory in map filter UI.
+     * Legacy RNM::Ore matches new RNM::Ore#Desc_* markers with the same base.
+     * @param FilterCategory - Selected filter category.
+     * @param MarkerCategory - Marker CategoryName.
+     */
+    static bool CategoryMatchesRNMFilter(const FString& FilterCategory, const FString& MarkerCategory);
+
+    /**
+     * Parses a stable resource class id embedded in CategoryName.
+     * @param Category - Expected form RNM::Ore#Desc_OreIron_C or RNM::Fluid#Desc_Water_C.
+     * @param OutClassFName - UClass FName when parsing succeeds.
+     * @return true if a # suffix was present and recognized.
+     */
     static bool TryParseClassIdFromCategory(const FString& Category, FName& OutClassFName);
 
-    /** Legacy markers only: optional embedded id in Name suffix " #RNM:ClassName" (new markers omit this). */
+    /**
+     * Parses a stable class id from a legacy marker name suffix.
+     * @param MarkerName - Name that may end with " #RNM:ClassName" (older markers only).
+     * @param OutClassFName - UClass FName when parsing succeeds.
+     * @return true if the suffix was found.
+     */
     static bool TryParseClassIdFromMarkerName(const FString& MarkerName, FName& OutClassFName);
 
-    /** Short UI category only: RNM::Ore or RNM::Fluid */
-    static FString BuildCategoryName(bool bIsFluid);
+    /**
+     * Builds the map filter category string for an RNM marker.
+     * @param bIsFluid - true for liquids/gases (RNM::Fluid), false for solids (RNM::Ore).
+     * @param StableClassId - Optional UClass FName appended after # for locale-safe rebuild.
+     * @return Category string stored on FMapMarker::CategoryName.
+     */
+    static FString BuildCategoryName(bool bIsFluid, FName StableClassId = NAME_None);
 
+    /** Squared distance (uu) used to match extractor placement to a scanned node location. */
     static constexpr float MARKER_LOCATION_TOLERANCE_SQ = 100.0f * 100.0f;
 
 private:
+    /** Localized display name plus purity counts, e.g. "Iron Ore (2 Pure, 1 Normal)". */
     static FString BuildClusterMarkerName(const FResourceNodeCluster& Cluster);
 };

--- a/Source/ResourceNodeMarker/Public/RNM_NodeScanner.h
+++ b/Source/ResourceNodeMarker/Public/RNM_NodeScanner.h
@@ -5,6 +5,7 @@
 #include "FGResourceNode.h"
 #include "RNM_ResourceNodeInfo.h"
 
+/** World scan and 2D spatial indexing for resource node proximity queries. */
 class RNM_NodeScanner
 {
 public:
@@ -12,30 +13,38 @@ public:
     ~RNM_NodeScanner() = default;
 
     /**
-     * Scan the world for extractable unoccupied resource nodes.
+     * Scans the world for extractable, unoccupied resource nodes.
      * @param World - The world to scan.
-     * @param OutNodes - Array to store found nodes.
+     * @param OutNodes - Filled with node actor, location, class FName, and purity.
      */
     static void ScanNodes(UWorld* World, TArray<FResourceNodeInfo>& OutNodes);
 
     /**
-     * Builds a spatial grid from scanned nodes for efficient proximity lookups.
+     * Builds a 2D spatial grid from scanned nodes for neighbor lookups.
      * @param Nodes - The scanned nodes to index.
-     * @param OutGrid - Map of grid cell to node indices.
+     * @param OutGrid - Map of grid cell to node indices in Nodes.
+     * @param CellSizeCm - Cell edge length in cm; should match configured cluster radius.
      */
     static void BuildSpatialGrid(
         const TArray<FResourceNodeInfo>& Nodes,
         TMap<FIntVector, TArray<int32>>& OutGrid,
         float CellSizeCm);
 
-    /** Returns the grid cell for a given world location. CellSizeCm should match Config.ClusterRadius * 100. */
+    /**
+     * Returns the grid cell containing a world location (Z ignored).
+     * @param Location - World position in cm.
+     * @param CellSizeCm - Cell edge length in cm; should match configured cluster radius.
+     */
     static FIntVector GetGridCell(const FVector& Location, float CellSizeCm);
 
     /**
-     * Returns all node indices in the given cell and its 8 neighbors.
+     * Returns node indices in the given cell and its eight neighbors.
+     * @param Grid - Spatial grid produced by BuildSpatialGrid.
+     * @param Cell - Center cell from GetGridCell.
+     * @return Flat list of indices into the original Nodes array.
      */
     static TArray<int32> GetNeighborCellIndices(const TMap<FIntVector, TArray<int32>>& Grid, const FIntVector& Cell);
 
-    /** Default cluster radius when config is unavailable (250m in cm). */
+    /** Default cluster radius when config is unavailable (250 m, in cm). */
     static constexpr float DEFAULT_CLUSTER_RADIUS_CM = 25000.0f;
 };

--- a/Source/ResourceNodeMarker/Public/RNM_ResourceNodeInfo.h
+++ b/Source/ResourceNodeMarker/Public/RNM_ResourceNodeInfo.h
@@ -10,15 +10,21 @@ struct FResourceNodeInfo
 {
     GENERATED_BODY()
 
+    /** Live world actor; may be null after reload if not rescanned. */
     UPROPERTY()
     AFGResourceNode* NodeActor = nullptr;
 
+    /** World location at scan time (cm). */
     FVector Location;
+
     /** UClass FName of UFGResourceDescriptor — language-invariant, safe for save/rebuild and visuals. */
     FName ResourceName;
-    /** Same as GetResourceClass() at scan time; kept so markers still resolve visuals if NodeActor is gone. */
+
+    /** Cached GetResourceClass() at scan time; used when NodeActor is unavailable. */
     UPROPERTY()
     TSubclassOf<UFGResourceDescriptor> ResourceDescriptorClass = nullptr;
+
+    /** Node purity at scan time. */
     EResourcePurity Purity;
 };
 
@@ -27,15 +33,33 @@ struct FResourceNodeCluster
 {
     GENERATED_BODY()
 
+    /** Nodes grouped under one map marker. */
     TArray<FResourceNodeInfo> Nodes;
+
+    /** Centroid of Nodes; used as marker location. */
     FVector AverageLocation = FVector::ZeroVector;
+
     /** UFGResourceDescriptor UClass FName, same as FResourceNodeInfo::ResourceName. */
     FName ResourceName;
-    EResourcePurity DominantPurity = RP_Normal;
-    FGuid CurrentMarkerGUID; // track the active marker so it can be deleted on update
 
+    /** Purity with the highest node count; drives marker color. */
+    EResourcePurity DominantPurity = RP_Normal;
+
+    /** Active map marker guid; invalidated when the marker is removed. */
+    FGuid CurrentMarkerGUID;
+
+    /** Recomputes AverageLocation from Nodes. */
     void RecalculateCenter();
+
+    /** Recomputes DominantPurity from node purity counts. */
     void RecalculateDominantPurity();
+
+    /** Appends Other.Nodes and recalculates center and dominant purity. */
     void MergeWith(const FResourceNodeCluster& Other);
+
+    /**
+     * Map marker scale based on node count in the cluster.
+     * @return Scale factor passed to FMapMarker::Scale.
+     */
     float GetMarkerScale() const;
 };

--- a/Source/ResourceNodeMarker/Public/RNM_ResourceVisuals.h
+++ b/Source/ResourceNodeMarker/Public/RNM_ResourceVisuals.h
@@ -12,23 +12,24 @@ struct FResourceVisual
 {
     GENERATED_BODY()
 
-    // Icon ID (integer from MapManager's icon list)
+    /** Map manager icon id (stamp or in-game resource icon depending on config). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Visual")
-    int32 IconID = 656; // default ore icon
+    int32 IconID = 656;
 
-    // Colors for each purity level
+    /** Marker tint when the cluster's dominant purity is Pure. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Visual")
     FLinearColor PureColor = FLinearColor::White;
 
+    /** Marker tint when the cluster's dominant purity is Normal. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Visual")
     FLinearColor NormalColor = FLinearColor::White;
 
+    /** Marker tint when the cluster's dominant purity is Impure. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Visual")
     FLinearColor ImpureColor = FLinearColor::White;
-
 };
 
-// Icon presets
+/** Default AFGMapManager stamp icon ids (rock, fluid, etc.). */
 struct FStampPreset
 {
     int Rock = 660;
@@ -41,6 +42,7 @@ struct FStampPreset
     int QuestionMark = 656;
 };
 
+/** Per-resource in-game map icon ids when bUseIcons is enabled. */
 struct FIconsPreset
 {
     int Copper = 198;
@@ -55,6 +57,7 @@ struct FIconsPreset
     int Sam = 280;
 };
 
+/** Lookup table for resource icon ids and purity tint colors. */
 UCLASS(Blueprintable)
 class RESOURCENODEMARKER_API URNM_ResourceVisuals : public UObject
 {
@@ -68,18 +71,30 @@ public:
     URNM_ResourceVisuals();
 
     /**
-     * Keys: prefer UFGResourceDescriptor UClass FName (e.g. Desc_OreIron_C).
-     * Legacy entries keyed by English display name (e.g. from GetItemName) still resolve via GetResourceVisual(..., ResClass, ...).
+     * Editor/overridable map of resource keys to icon and purity colors.
+     * Keys include UClass FNames (Desc_OreIron_C) and legacy English display names.
      */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Resources")
     TMap<FName, FResourceVisual> ResourceVisualMap;
 
-    /** Resolves visuals using class FName, then _C strip, then localized display name as FName (matches legacy map keys). */
+    /**
+     * Resolves icon and purity colors for a resource.
+     * Prefer GetResourceVisual(..., ResClass, ...) when a descriptor class is available.
+     * @param ResourceName - UClass FName or legacy display key.
+     * @param bUseIcons - When false, uses stock rock/fluid stamps; when true, per-resource icons.
+     * @return Visual data applied to new map markers.
+     */
     UFUNCTION(BlueprintPure, Category = "Resources")
     FResourceVisual GetResourceVisual(const FName& ResourceName, bool bUseIcons) const;
 
     /**
-     * @param OptionalLegacyDisplayKey FName of the node's current GetResourceName() string; helps match old map keys.
+     * Resolves icon and purity colors for a resource.
+     * Lookup order: UClass FName, class-name pattern, then localized display names.
+     * @param ResourceClassFName - Stable descriptor UClass FName (e.g. Desc_OreIron_C).
+     * @param ResClass - Optional descriptor class for form detection and extra keys.
+     * @param bUseIcons - When false, uses stock rock/fluid stamps; when true, per-resource icons.
+     * @param OptionalLegacyDisplayKey - Localized GetResourceName() for old save compatibility.
+     * @return Visual data applied to new map markers.
      */
     FResourceVisual GetResourceVisual(
         const FName& ResourceClassFName,
@@ -88,10 +103,12 @@ public:
         FName OptionalLegacyDisplayKey = NAME_None) const;
 
     /**
-     * Generates Pure/Normal/Impure shades from a single base color.
-     * Pure   ? more saturated, darker (rich/vivid)
-     * Normal ? base color
-     * Impure ? less saturated, brighter (washed out)
+     * Derives Pure, Normal, and Impure tints from a single base color.
+     * Pure is more saturated and darker; Impure is desaturated and brighter.
+     * @param BaseColor - Normal-purity reference color.
+     * @param OutPure - Output tint for pure nodes.
+     * @param OutNormal - Output tint for normal nodes (same as BaseColor).
+     * @param OutImpure - Output tint for impure nodes.
      */
     static void GeneratePurityShades(
         const FLinearColor& BaseColor,

--- a/Source/ResourceNodeMarker/Public/RNM_WorldSubsystem.h
+++ b/Source/ResourceNodeMarker/Public/RNM_WorldSubsystem.h
@@ -11,21 +11,36 @@
 #include "FGBuildableSubsystem.h"
 #include "RNM_WorldSubsystem.generated.h"
 
+/**
+ * Game-world orchestrator: config load, node scan, proximity discovery, extractor handling.
+ * One instance per gameplay UWorld; owns scanned nodes, spatial grid, and cluster state.
+ */
 UCLASS()
 class RESOURCENODEMARKER_API URNM_WorldSubsystem : public UWorldSubsystem
 {
     GENERATED_BODY()
 
 public:
+    /** Registers OnWorldBeginPlay hooks and creates ResourceVisuals / ClusterManager. */
     virtual void Initialize(FSubsystemCollectionBase& Collection) override;
+
+    /** Clears proximity timer and buildable delegate bindings. */
     virtual void Deinitialize() override;
 
 private:
+    /** Loads config, scans nodes, rebuilds markers, and starts the proximity timer. */
     void InitializeConfig();
+
+    /** Rescans nodes, rebuilds cluster state, and recreates all RNM map markers. */
     void ScanAllNodes();
+
+    /** Timer callback: discovers nodes within ProximityRadius of the local player. */
     void CheckPlayerProximity();
+
+    /** Subscribes to AFGBuildableSubsystem::mBuildableAddedDelegate for extractor detection. */
     void BindBuildableDelegate();
 
+    /** Handles extractor placement when ExtractorMarkerBehavior is Remove (1). */
     UFUNCTION()
     void OnBuildableConstructed(AFGBuildable* Buildable);
 

--- a/Source/ResourceNodeMarker/Public/ResourceNodeMarker_ConfigStruct.h
+++ b/Source/ResourceNodeMarker/Public/ResourceNodeMarker_ConfigStruct.h
@@ -21,7 +21,7 @@ public:
     bool bMarkImpure = true;
 
     UPROPERTY(BlueprintReadWrite)
-    float ProximityRadius = 160.0f; //meters, converted to cm in code
+    float ProximityRadius = 160.0f; // meters, converted to cm in code
 
     UPROPERTY(BlueprintReadWrite)
     int32 CompassViewDistance = 2; // 2 = Mid
@@ -51,24 +51,55 @@ public:
     UPROPERTY(BlueprintReadWrite)
     bool bClusterNodes = true;
 
-    static float GetClusterRadiusCm(const FResourceNodeMarker_ConfigStruct& Config)
-    {
-        return FMath::Max(Config.ClusterRadius * 100.0f, 1.0f);
-    }
-
-    static float GetClusterHeightToleranceCm(const FResourceNodeMarker_ConfigStruct& Config)
-    {
-        return FMath::Max(Config.ClusterHeightTolerance * 100.0f, 0.0f);
-    }
-
+    /**
+     * Returns whether nearby nodes of the same resource share one marker.
+     * @param Config - Active mod configuration.
+     */
     static bool IsClusteringEnabled(const FResourceNodeMarker_ConfigStruct& Config)
     {
         return Config.bClusterNodes;
     }
 
-    /** Maps legacy config values after load (e.g. Highlight → Remove). Called by GetActiveConfig. */
+    /**
+     * Converts configured proximity radius from meters to cm with a minimum of 1 cm.
+     * @param Config - Active mod configuration.
+     */
+    static float GetProximityRadiusCm(const FResourceNodeMarker_ConfigStruct& Config)
+    {
+        return FMath::Max(Config.ProximityRadius * 100.0f, 1.0f);
+    }
+
+    /**
+     * Converts configured cluster radius from meters to cm with a minimum of 1 cm.
+     * @param Config - Active mod configuration.
+     */
+    static float GetClusterRadiusCm(const FResourceNodeMarker_ConfigStruct& Config)
+    {
+        return FMath::Max(Config.ClusterRadius * 100.0f, 1.0f);
+    }
+
+    /**
+     * Converts configured Z tolerance from meters to cm; negative values clamp to 0.
+     * @param Config - Active mod configuration.
+     */
+    static float GetClusterHeightToleranceCm(const FResourceNodeMarker_ConfigStruct& Config)
+    {
+        return FMath::Max(Config.ClusterHeightTolerance * 100.0f, 0.0f);
+    }
+
+    /**
+     * Maps legacy config values after load (e.g. Highlight → Remove).
+     * Called by GetActiveConfig; not needed when filling the struct elsewhere.
+     * @param Config - Config struct to normalize in place.
+     */
     static void NormalizeLegacyValues(FResourceNodeMarker_ConfigStruct& Config);
 
+    /**
+     * Loads the active mod configuration from SML ConfigManager.
+     * Returns defaults when world, game instance, or config registration is missing.
+     * @param WorldContext - Object used to resolve UWorld (typically the world subsystem).
+     * @return Populated config struct with legacy values normalized.
+     */
     static FResourceNodeMarker_ConfigStruct GetActiveConfig(UObject* WorldContext);
 };
 


### PR DESCRIPTION
Summary
Fixes map marker stamp colors and labels breaking when the game runs in a non-English locale.

Root cause: visual lookup leaned on English display names and localized GetResourceName() keys. Non-English clients missed ResourceVisualMap → white/default marker tints.

Changes:

Resolve visuals by stable UClass FName (Desc_OreIron_C) first, then Desc_* catalog patterns (longest match, boundary-safe), then localized display names as fallback
Single ResourceCatalog table for hex colors, icon ids, and map keys (no duplicate ctor tables)
Embed stable class id in CategoryName (RNM::Ore#Desc_OreIron_C) for locale-safe save/rebuild matching
Localized marker titles: resource name from game APIs; purity labels via GetResoucePurityText() with enum/fallback chain
Neutral gray purity tints for unknown/mod resources instead of white
Shared cluster helpers (ResolveClusterResourceContext, fluid inference, display label)
GetProximityRadiusCm — config distances stay in meters, convert to cm at runtime
API doc pass on public headers
Known follow-up (not in this PR): map filter dropdown may show RNM::Ore#Desc_* — plan to use plain RNM::Ore / RNM::Fluid for UI after in-game verification.

Test plan

- [ ] English client: stamp mode (bUseIcons=false) — iron/copper/etc. colored markers

- [ ] Non-English client: same — stamp colors not white

- [ ] Non-English client: marker title shows localized resource + purity text

- [ ] bUseIcons=true — per-resource icons + correct tints

- [ ] Save/load — markers recreated; discovery/clusters sane

- [ ] Legacy save with old RNM::Ore markers — deleted/rebuilt without crash

- [ ] Map filter dropdown — note what category strings appear (for follow-up PR)

- [ ] Modded/unknown resource — gray fallback tint, no spam warnings after cap

- [ ] Clustering on/off, proximity discovery, extractor remove behavior unchanged