### PR TITLE
fix(rnm): localized marker categories and visuals

### DIFF
--- a/Source/ResourceNodeMarker/Private/RNM_ClusterManager.cpp
+++ b/Source/ResourceNodeMarker/Private/RNM_ClusterManager.cpp
@@ -81,12 +81,15 @@ void URNM_ClusterManager::RebuildClustersFromExistingMarkers(UWorld* World)
     AFGMapManager* MapManager = AFGMapManager::Get(World);
     if (!MapManager) return;
 
+    const TSet<FString> KnownDisplayCategories =
+        RNM_MapMarkerService::CollectKnownDisplayCategories(*ResourceNodes);
+
     TArray<FMapMarker> ExistingMarkers;
     MapManager->GetMapMarkers(ExistingMarkers);
 
     for (const FMapMarker& Marker : ExistingMarkers)
     {
-        if (!RNM_MapMarkerService::IsRNMMapMarkerCategory(Marker.CategoryName))
+        if (!RNM_MapMarkerService::IsRNMMapMarkerCategory(Marker.CategoryName, &KnownDisplayCategories))
             continue;
 
         FName StableClassId;
@@ -106,7 +109,8 @@ void URNM_ClusterManager::RebuildClustersFromExistingMarkers(UWorld* World)
                 NameForLegacy = NameForLegacy.Left(TagIdx);
         }
         const int32 ParenIdx = NameForLegacy.Find(TEXT(" ("));
-        const FString LegacyPrefix = (ParenIdx != INDEX_NONE) ? NameForLegacy.Left(ParenIdx) : NameForLegacy;
+        const FString LegacyPrefix = RNM_MapMarkerService::StripRichTextMarkup(
+            (ParenIdx != INDEX_NONE) ? NameForLegacy.Left(ParenIdx) : NameForLegacy);
 
         TArray<int32> ClusterNodeIndices;
         for (int32 NodeIndex : CandidateIndices)
@@ -199,13 +203,17 @@ void URNM_ClusterManager::DeleteAllRNMMarkers(UWorld* World)
     AFGMapManager* MapManager = AFGMapManager::Get(World);
     if (!MapManager) return;
 
+    const TSet<FString> KnownDisplayCategories = ResourceNodes
+        ? RNM_MapMarkerService::CollectKnownDisplayCategories(*ResourceNodes)
+        : TSet<FString>();
+
     TArray<FMapMarker> AllMarkers;
     MapManager->GetMapMarkers(AllMarkers);
 
     TArray<FMapMarker> MarkersToRemove;
     for (const FMapMarker& Marker : AllMarkers)
     {
-        if (RNM_MapMarkerService::IsRNMMapMarkerCategory(Marker.CategoryName))
+        if (RNM_MapMarkerService::IsRNMMapMarkerCategory(Marker.CategoryName, &KnownDisplayCategories))
         {
             MarkersToRemove.Add(Marker);
         }

--- a/Source/ResourceNodeMarker/Private/RNM_MapMarkerService.cpp
+++ b/Source/ResourceNodeMarker/Private/RNM_MapMarkerService.cpp
@@ -27,24 +27,15 @@ void ResolveClusterResourceContext(
         if (!OutResClass && N.NodeActor)
             OutResClass = N.NodeActor->GetResourceClass();
         if (OutLegacyDisplayKey == NAME_None && N.NodeActor)
-            OutLegacyDisplayKey = FName(*N.NodeActor->GetResourceName().ToString());
+        {
+            const FText ResourceName = N.NodeActor->GetResourceName();
+            if (!ResourceName.IsEmpty())
+            {
+                OutLegacyDisplayKey = FName(*RNM_MapMarkerService::StripRichTextMarkup(
+                    ResourceName.ToString()));
+            }
+        }
     }
-}
-
-bool InferIsFluidResource(const FName ClassKey, TSubclassOf<UFGResourceDescriptor> ResClass, const FResourceVisual& Visual)
-{
-    if (ResClass)
-    {
-        const EResourceForm Form = UFGItemDescriptor::GetForm(ResClass);
-        return Form == EResourceForm::RF_LIQUID || Form == EResourceForm::RF_GAS;
-    }
-
-    const FString ClassStr = ClassKey.ToString();
-    if (ClassStr.Contains(TEXT("Liquid")) || ClassStr.Contains(TEXT("Desc_Water")) || ClassStr.Contains(TEXT("WaterGeyser")))
-        return true;
-
-    FStampPreset Icons;
-    return Visual.IconID == Icons.Fluids;
 }
 
 FString GetClusterResourceDisplayLabel(
@@ -54,14 +45,29 @@ FString GetClusterResourceDisplayLabel(
     for (const FResourceNodeInfo& N : Cluster.Nodes)
     {
         if (N.NodeActor)
-            return N.NodeActor->GetResourceName().ToString();
+        {
+            if (TSubclassOf<UFGResourceDescriptor> NodeClass = N.NodeActor->GetResourceClass())
+            {
+                const FText ItemName = UFGItemDescriptor::GetItemName(NodeClass);
+                if (!ItemName.IsEmpty())
+                {
+                    return RNM_MapMarkerService::StripRichTextMarkup(ItemName.ToString());
+                }
+            }
+
+            const FText ResourceName = N.NodeActor->GetResourceName();
+            if (!ResourceName.IsEmpty())
+            {
+                return RNM_MapMarkerService::StripRichTextMarkup(ResourceName.ToString());
+            }
+        }
     }
 
     if (ResClass)
     {
         const FText ItemName = UFGItemDescriptor::GetItemName(ResClass);
         if (!ItemName.IsEmpty())
-            return ItemName.ToString();
+            return RNM_MapMarkerService::StripRichTextMarkup(ItemName.ToString());
     }
 
     return Cluster.ResourceName.ToString();
@@ -76,7 +82,7 @@ FString GetPurityDisplayLabel(const FResourceNodeCluster& Cluster, const EResour
 
         const FText GameLabel = Node.NodeActor->GetResoucePurityText();
         if (!GameLabel.IsEmpty())
-            return GameLabel.ToString();
+            return RNM_MapMarkerService::StripRichTextMarkup(GameLabel.ToString());
         continue;
     }
 
@@ -87,7 +93,7 @@ FString GetPurityDisplayLabel(const FResourceNodeCluster& Cluster, const EResour
         {
             const FText EnumLabel = PurityEnum->GetDisplayNameTextByValue(EnumValue);
             if (!EnumLabel.IsEmpty())
-                return EnumLabel.ToString();
+                return RNM_MapMarkerService::StripRichTextMarkup(EnumLabel.ToString());
         }
     }
 
@@ -145,7 +151,8 @@ bool RNM_MapMarkerService::CreateOrUpdateClusterMarker(
     const FName VisualClassKey = ResClass ? ResClass->GetFName() : Cluster.ResourceName;
     FResourceVisual Visual = ResourceVisuals->GetResourceVisual(
         VisualClassKey, ResClass, Config.bUseIcons, LegacyDisplayKey);
-    const bool bIsFluid = InferIsFluidResource(VisualClassKey, ResClass, Visual);
+
+    const FString DisplayLabel = GetClusterResourceDisplayLabel(Cluster, ResClass);
 
     FMapMarker Marker;
     Marker.MarkerGUID = FGuid::NewGuid();
@@ -154,8 +161,8 @@ bool RNM_MapMarkerService::CreateOrUpdateClusterMarker(
     Marker.MapMarkerType = ERepresentationType::RT_MapMarker;
     Marker.IconID = Visual.IconID;
     Marker.Scale = Cluster.GetMarkerScale();
-    Marker.Name = BuildClusterMarkerName(Cluster);
-    Marker.CategoryName = BuildCategoryName(bIsFluid, VisualClassKey);
+    Marker.Name = BuildClusterMarkerName(Cluster, DisplayLabel);
+    Marker.CategoryName = BuildCategoryName(DisplayLabel);
     Marker.CompassViewDistance = ParseCompassViewDistance(Config.CompassViewDistance);
 
     switch (Cluster.DominantPurity)
@@ -196,7 +203,9 @@ bool RNM_MapMarkerService::CreateOrUpdateClusterMarker(
     return true;
 }
 
-FString RNM_MapMarkerService::BuildClusterMarkerName(const FResourceNodeCluster& Cluster)
+FString RNM_MapMarkerService::BuildClusterMarkerName(
+    const FResourceNodeCluster& Cluster,
+    const FString& ResourceLabel)
 {
     int32 PureCount = 0;
     int32 NormalCount = 0;
@@ -229,26 +238,70 @@ FString RNM_MapMarkerService::BuildClusterMarkerName(const FResourceNodeCluster&
         PurityStr += FormatPurityCountSegment(Cluster, ImpureCount, RP_Inpure);
     }
 
-    TSubclassOf<UFGResourceDescriptor> ResClass = nullptr;
-    FName UnusedLegacyKey = NAME_None;
-    ResolveClusterResourceContext(Cluster, ResClass, UnusedLegacyKey);
-
-    const FString ResourceLabel = GetClusterResourceDisplayLabel(Cluster, ResClass);
-
     if (PurityStr.IsEmpty())
         return ResourceLabel;
 
     return FString::Printf(TEXT("%s (%s)"), *ResourceLabel, *PurityStr);
 }
 
-bool RNM_MapMarkerService::IsRNMMapMarkerCategory(const FString& Category)
+FString RNM_MapMarkerService::StripRichTextMarkup(const FString& Text)
 {
-    return Category == TEXT("RNM::Ore") || Category == TEXT("RNM::Fluid")
-        || Category.StartsWith(TEXT("RNM::Ore#")) || Category.StartsWith(TEXT("RNM::Fluid#"));
+    FString Plain = Text;
+    for (;;)
+    {
+        const int32 Open = Plain.Find(TEXT("<"), ESearchCase::CaseSensitive);
+        if (Open == INDEX_NONE)
+            break;
+
+        const int32 Close = Plain.Find(TEXT(">"), ESearchCase::CaseSensitive, ESearchDir::FromStart, Open);
+        if (Close == INDEX_NONE)
+            break;
+
+        Plain.RemoveAt(Open, Close - Open + 1);
+    }
+    return Plain.TrimStartAndEnd();
+}
+
+bool RNM_MapMarkerService::IsRNMMapMarkerCategory(
+    const FString& Category,
+    const TSet<FString>* KnownDisplayCategories)
+{
+    if (Category == TEXT("RNM::Ore") || Category == TEXT("RNM::Fluid")
+        || Category.StartsWith(TEXT("RNM::Ore#")) || Category.StartsWith(TEXT("RNM::Fluid#")))
+        return true;
+
+    if (!KnownDisplayCategories)
+        return false;
+
+    const FString PlainCategory = StripRichTextMarkup(Category);
+    return KnownDisplayCategories->Contains(PlainCategory);
+}
+
+TSet<FString> RNM_MapMarkerService::CollectKnownDisplayCategories(const TArray<FResourceNodeInfo>& Nodes)
+{
+    TSet<FString> Categories;
+    for (const FResourceNodeInfo& Node : Nodes)
+    {
+        if (Node.ResourceDescriptorClass)
+        {
+            const FText ItemName = UFGItemDescriptor::GetItemName(Node.ResourceDescriptorClass);
+            if (!ItemName.IsEmpty())
+                Categories.Add(StripRichTextMarkup(ItemName.ToString()));
+        }
+
+        if (Node.NodeActor)
+        {
+            const FText ResourceName = Node.NodeActor->GetResourceName();
+            if (!ResourceName.IsEmpty())
+                Categories.Add(StripRichTextMarkup(ResourceName.ToString()));
+        }
+    }
+    return Categories;
 }
 
 bool RNM_MapMarkerService::TryParseClassIdFromCategory(const FString& Category, FName& OutClassFName)
 {
+    // Legacy markers only (RNM::Ore#Desc_OreIron_C). New markers use localized CategoryName.
     OutClassFName = NAME_None;
     if (IsLegacyRNMCategoryWithoutClassId(Category))
         return false;
@@ -280,12 +333,9 @@ bool RNM_MapMarkerService::TryParseClassIdFromMarkerName(const FString& MarkerNa
     return true;
 }
 
-FString RNM_MapMarkerService::BuildCategoryName(const bool bIsFluid, const FName StableClassId)
+FString RNM_MapMarkerService::BuildCategoryName(const FString& LocalizedDisplayLabel)
 {
-    const FString Base = bIsFluid ? TEXT("RNM::Fluid") : TEXT("RNM::Ore");
-    if (StableClassId != NAME_None)
-        return FString::Printf(TEXT("%s#%s"), *Base, *StableClassId.ToString());
-    return Base;
+    return StripRichTextMarkup(LocalizedDisplayLabel);
 }
 
 ECompassViewDistance RNM_MapMarkerService::ParseCompassViewDistance(int32 Value)

--- a/Source/ResourceNodeMarker/Private/RNM_ResourceVisuals.cpp
+++ b/Source/ResourceNodeMarker/Private/RNM_ResourceVisuals.cpp
@@ -2,6 +2,7 @@
 #include "ResourceNodeMarker.h"
 #include "FGItemDescriptor.h"
 #include "FGResourceDescriptor.h"
+#include "FGResourceDescriptorGeyser.h"
 
 namespace
 {
@@ -54,7 +55,8 @@ static const TCHAR* LimestoneMapKeys[] = {
 static const TCHAR* CateriumMapKeys[] = {
     TEXT("Caterium Ore"), TEXT("Desc_OreCaterium_C"), TEXT("Desc_OreCaterium"), TEXT("BP_OreCaterium_C") };
 static const TCHAR* CoalMapKeys[] = {
-    TEXT("Coal"), TEXT("Desc_OreCoal_C"), TEXT("Desc_OreCoal"), TEXT("BP_OreCoal_C") };
+    TEXT("Coal"), TEXT("Desc_Coal_C"), TEXT("Desc_Coal"), TEXT("BP_Coal_C"),
+    TEXT("Desc_OreCoal_C"), TEXT("Desc_OreCoal"), TEXT("BP_OreCoal_C") };
 static const TCHAR* SulfurMapKeys[] = {
     TEXT("Sulfur"), TEXT("Desc_OreSulfur_C"), TEXT("Desc_OreSulfur"), TEXT("BP_OreSulfur_C") };
 static const TCHAR* BauxiteMapKeys[] = {
@@ -87,6 +89,7 @@ static const FResourceCatalogEntry ResourceCatalog[] = {
     { TEXT("Desc_OreSulfur"), TEXT("E6E615"), false, InGameIcon::Sulfur, SulfurMapKeys, UE_ARRAY_COUNT(SulfurMapKeys) },
     { TEXT("Desc_OreIron"), TEXT("93959E"), false, InGameIcon::Iron, IronMapKeys, UE_ARRAY_COUNT(IronMapKeys) },
     { TEXT("Desc_Stone"), TEXT("D1B97B"), false, InGameIcon::Limestone, LimestoneMapKeys, UE_ARRAY_COUNT(LimestoneMapKeys) },
+    { TEXT("Desc_Coal"), TEXT("403B3B"), false, InGameIcon::Coal, CoalMapKeys, UE_ARRAY_COUNT(CoalMapKeys) },
     { TEXT("Desc_OreCoal"), TEXT("403B3B"), false, InGameIcon::Coal, CoalMapKeys, UE_ARRAY_COUNT(CoalMapKeys) },
     { TEXT("Desc_OreSAM"), TEXT("A332C9"), false, InGameIcon::Sam, SamMapKeys, UE_ARRAY_COUNT(SamMapKeys) },
     { TEXT("Desc_SAM"), TEXT("A332C9"), false, InGameIcon::Sam, SamMapKeys, UE_ARRAY_COUNT(SamMapKeys) },
@@ -153,6 +156,15 @@ int32 GetStampIconIdForOreOrFluid(TSubclassOf<UFGResourceDescriptor> ResClass)
     if (Form == EResourceForm::RF_LIQUID || Form == EResourceForm::RF_GAS)
         return Sp.Fluids;
 
+    if (ResClass->IsChildOf(UFGResourceDescriptorGeyser::StaticClass()))
+        return Sp.Fluids;
+
+    if (const FResourceCatalogEntry* Entry = FindResourceCatalogEntry(ResClass->GetName()))
+    {
+        if (Entry->bLiquid)
+            return Sp.Fluids;
+    }
+
     return Sp.Rock;
 }
 
@@ -165,8 +177,15 @@ int32 ResolveInGameIconIdFromResourceClass(TSubclassOf<UFGResourceDescriptor> Re
     if (Form == EResourceForm::RF_LIQUID || Form == EResourceForm::RF_GAS)
         return Sp.Fluids;
 
+    if (ResClass->IsChildOf(UFGResourceDescriptorGeyser::StaticClass()))
+        return Sp.Fluids;
+
     if (const FResourceCatalogEntry* Entry = FindResourceCatalogEntry(ResClass->GetName()))
+    {
+        if (Entry->bLiquid)
+            return Sp.Fluids;
         return Entry->IconId != 0 ? Entry->IconId : Sp.Rock;
+    }
 
     return Sp.Rock;
 }
@@ -296,6 +315,14 @@ URNM_ResourceVisuals::URNM_ResourceVisuals()
             ResourceVisualMap.Add(FName(Entry.MapKeys[i]), Visual);
             if (Entry.IconId != 0)
                 IconMap.Add(FName(Entry.MapKeys[i]), Entry.IconId);
+        }
+
+        ResourceVisualMap.Add(FName(Entry.ClassPattern), Visual);
+        ResourceVisualMap.Add(FName(FString::Printf(TEXT("%s_C"), Entry.ClassPattern)), Visual);
+        if (Entry.IconId != 0)
+        {
+            IconMap.Add(FName(Entry.ClassPattern), Entry.IconId);
+            IconMap.Add(FName(FString::Printf(TEXT("%s_C"), Entry.ClassPattern)), Entry.IconId);
         }
     }
 }

--- a/Source/ResourceNodeMarker/Public/RNM_MapMarkerService.h
+++ b/Source/ResourceNodeMarker/Public/RNM_MapMarkerService.h
@@ -40,10 +40,19 @@ public:
 
     /**
      * Returns true if Category is an RNM-owned marker category.
-     * Accepts legacy RNM::Ore / RNM::Fluid and stable RNM::Ore#ClassFName forms.
+     * Accepts legacy RNM::Ore / RNM::Fluid / RNM::Ore#ClassFName and localized display categories.
      * @param Category - FMapMarker::CategoryName from the map manager.
+     * @param KnownDisplayCategories - Required for localized categories; pass from CollectKnownDisplayCategories.
      */
-    static bool IsRNMMapMarkerCategory(const FString& Category);
+    static bool IsRNMMapMarkerCategory(
+        const FString& Category,
+        const TSet<FString>* KnownDisplayCategories);
+
+    /** Removes Satisfactory rich-text markup (e.g. &lt;Bold&gt;) from map marker strings. */
+    static FString StripRichTextMarkup(const FString& Text);
+
+    /** Localized resource display labels for all scanned node types in this session. */
+    static TSet<FString> CollectKnownDisplayCategories(const TArray<FResourceNodeInfo>& Nodes);
 
     /**
      * Parses a stable resource class id embedded in CategoryName.
@@ -62,17 +71,18 @@ public:
     static bool TryParseClassIdFromMarkerName(const FString& MarkerName, FName& OutClassFName);
 
     /**
-     * Builds the map filter category string for an RNM marker.
-     * @param bIsFluid - true for liquids/gases (RNM::Fluid), false for solids (RNM::Ore).
-     * @param StableClassId - Optional UClass FName appended after # for locale-safe rebuild.
+     * Builds the map filter category string shown in the map UI dropdown.
+     * @param LocalizedDisplayLabel - Localized resource name (marker title resource part).
      * @return Category string stored on FMapMarker::CategoryName.
      */
-    static FString BuildCategoryName(bool bIsFluid, FName StableClassId = NAME_None);
+    static FString BuildCategoryName(const FString& LocalizedDisplayLabel);
 
     /** Squared distance (uu) used to match extractor placement to a scanned node location. */
     static constexpr float MARKER_LOCATION_TOLERANCE_SQ = 100.0f * 100.0f;
 
 private:
     /** Localized display name plus purity counts, e.g. "Iron Ore (2 Pure, 1 Normal)". */
-    static FString BuildClusterMarkerName(const FResourceNodeCluster& Cluster);
+    static FString BuildClusterMarkerName(
+        const FResourceNodeCluster& Cluster,
+        const FString& ResourceLabel);
 };


### PR DESCRIPTION
Non-English saves missed colors/categories via GetResourceName vs GetItemName and RNM::Ore#Desc_* filters. Use stripped localized labels; add Desc_Coal alias and geyser fluid stamp paths.